### PR TITLE
Make revision 1 of dangerous model

### DIFF
--- a/ubuntu-core-20-amd64-dangerous.json
+++ b/ubuntu-core-20-amd64-dangerous.json
@@ -3,34 +3,35 @@
     "series": "16",
     "authority-id": "canonical",
     "brand-id": "canonical",
+    "revision": "1",
     "model": "ubuntu-core-20-amd64-dangerous",
     "architecture": "amd64",
-    "timestamp": "2020-01-13T15:47:00.0Z",
+    "timestamp": "2020-04-29T11:18:00.0Z",
     "base": "core20",
     "grade": "dangerous",
     "snaps": [
         {
             "name": "pc",
             "type": "gadget",
-            "default-channel": "20/stable",
+            "default-channel": "20/edge",
             "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
         },
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "20/stable",
+            "default-channel": "20/edge",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {
             "name": "core20",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "latest/edge",
             "id": "DLqre5XGLbDqg9jPtiAhRRjDuPVa5X1q"
         },
         {
             "name": "snapd",
             "type": "snapd",
-            "default-channel": "latest/stable",
+            "default-channel": "latest/edge",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
         }
     ]


### PR DESCRIPTION
Switch from stable to edge channel, for pc-amd64 dangerous model.

Stable, as default channel, is not that useful. And livecd-rootfs currently doesn't know how to override per-snap channels with a graded model. And out of all channels, we care to have edge + dangerous builds.