### PR TITLE
Remove storage-safety for ubuntu-core-22-arm64*.json

### DIFF
--- a/ubuntu-core-22-arm64-beta.json
+++ b/ubuntu-core-22-arm64-beta.json
@@ -2,13 +2,13 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-22-arm64-beta",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
     "timestamp": "2023-03-02T02:03:23+00:00",
     "base": "core22",
     "grade": "signed",
-    "storage-safety": "prefer-unencrypted",
     "snaps": [
         {
             "name": "pc",

--- a/ubuntu-core-22-arm64-beta.model
+++ b/ubuntu-core-22-arm64-beta.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-arm64-beta
@@ -27,17 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-storage-safety: prefer-unencrypted
 timestamp: 2023-03-02T02:03:23+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZAD4TwAKCRDgT5vottzAEolTD/0RXvCpoltMYSOJXzoP9/dMDIAvQvgvCL+y
-P7q+qQUynebUSM068wxUxoeaGmgQvD3RTM+oUk11Tx3JjyuTWLUh18/vrWqSP0IeOE6Y+vCZokBB
-HE78qCEjBkPhbpLZoP8NSYUBgjqilfqptTh5lxE7UgV9QV9ROC9eZJFcGyl/cQfLTVYX7Fv9KFAG
-ROv9+FUIfmz0WO6ncOTvzIVupPM4BzHwQPqXCu72SDsx1MBVwFQsJfhkLPoCE1P8rbC7Cby6TGib
-4DDTaZCtPiEaHr+sYrReRm9nDaOt9j/MHE+At6nDdprX1a+u16XEYnLd4RbrBvYYQcupFzbTcLza
-7+uCczDhNT/4RQmoantU41tIE8n6nun8/5vJOzHJq2auGaZ2GrJoQZSO612LV6JTlDOTTmUTCOOx
-8MTTKwTk7sf+zOzEW6lJuqLwgIwDH99uegPyeFi8jCgU3fdi/o+340ZorR3hRm+bMAqFWcuQ3v7u
-ibBCUQ30XdPqnYs7z6Cs7RLsdE3hpbuLKWZTx9pNTgDWvJQVp5ebxrVPAQPOej6DGQadwERoe/ik
-4VjrdqjJ3dDKbBloSdIxpZtySUhdbSLMWS5MpQiWMKkL6vvlneS9iGSAi6MYwMuDzkHRL/0E4/zh
-cvV7Iy4zG/+TqeqiUa3MqQ/JdZTHrNztuHOFjqxlpA==
+AcLBXAQAAQoABgUCZKo7rwAKCRDgT5vottzAEgTUEAC9wJNLxfX4orF3PE5Q4ma4bh7Ooog8DLnn
++YFScKUGMC+bnRKckfom5LQmXOXDeCyFUxh+rFysfuRlNyCYcgkcosuifSL5M4akvrztJotL3yzc
+0FS9m49OC19F8Muakqt5eTVICoj51JNqjw5aNCIryWKRPR421llfmV9vPiPKYyJkmJKKezxbsJjO
+ZdnK210/dFUj4dQjyyOc75SbJut0AbHKl0cGQuENRNWybLDnABrxBRN4vWqo0ZwRQ3q7dbsUUXq8
+WF8jRKr8zCAhwlwjmLpeNGYKleBKzXFIX+s0LTCL19LOHOKDdaJPzWb8Bp9Dpjb+z2rAeVOU7Nq1
+u4j1hXVwzzDdSIY5FO5o1eg6cdyF67o+OZOB/gK1Ya6Gkn2B1M47aaSU/SjrJVAa/iRBrQSJur8+
+vb48hXms1jO9ZfTjJH9nGRIhbVkv6iYfgmSnQipDXFp2Ku3r+c1/E7xBjD13ABNqw1sVHrk6Etpi
+3OP4tSSx6231QNES8egI37Js97PsA+z33S6QttpZR3aAVxI6h+InlisLSezyde7lvo0CWI8h+g0E
+mX5Vugaz+cFHqY6/O76M5HT71zSm10AjI2rD5CF9DjSqZttQORR4bvt3gCZA12bg63JCfbjBmbnw
+c2byVsSFHjIR8CGc1Pr+gqmgWB7TA/X+OsbzfJau4A==

--- a/ubuntu-core-22-arm64-candidate.json
+++ b/ubuntu-core-22-arm64-candidate.json
@@ -2,13 +2,13 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-22-arm64-candidate",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
     "timestamp": "2023-03-02T02:03:23+00:00",
     "base": "core22",
     "grade": "signed",
-    "storage-safety": "prefer-unencrypted",
     "snaps": [
         {
             "name": "pc",

--- a/ubuntu-core-22-arm64-candidate.model
+++ b/ubuntu-core-22-arm64-candidate.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-arm64-candidate
@@ -27,17 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-storage-safety: prefer-unencrypted
 timestamp: 2023-03-02T02:03:23+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZAD4UAAKCRDgT5vottzAEux3D/9UzjgHhw2S/Lcp+gX3ADYZmEQaYv1HoMgp
-QLUOwD9XvCFrdI9KDnhxk9jYbXRfEeFWUGqVCXiL1b2aTzCPxpWpRZydaWqOhgQOLyL5I6fCwbM7
-HFlC/AFYGlwNxZmUxLwwtI04cndJvXg+hQoAPru4bUlG8ll1lEqnNYu3lfQGy637SH+pJj2C70MI
-Ozpn68b1xmVFzT8xQcqf0T83KB2OL0SDKoXJm7EnTCbKV0AjtrlxbExIj+4ZNBrIG7nK8GJ2Xi4V
-KQcpYgpHUAyb0LxVhG568TUqulJeYDvHQLa9OmX9yhtPeyS+ktG9AVgkGUfNcCNmEWL7xgTvmxNB
-uXaf8MSW6HAhAVRsyQNaAOEDqhdlCoMj9BFygBP2kA5Xl+SKIpZMv15JMHShj3Ad2/Xhcr893Qmd
-s2LOl+K7n5oWhb+FjrFqNiNhdgmN/vnw523sPkYk2dusBqjGwpqvp/cKHmqiBR7wSYFd8WkZXqKQ
-0/8lZZ3MioH2EFdXJ5Xb0NZZnIMa1fJYPOmsyY0IEpC5gXce5ne5E57Kwm5ZOBCazWdeQ/pOyvNi
-iBn3SgxYom6qgUgjgYemwYs3H4TejsWTOrheoRMJ6wDkp40NRB9O4BOQplx6kA7KVAVHbWd+ZiiD
-ryLhIbvzMu0nqojGqQ30GKW+4586S7oWTraLesGKNg==
+AcLBWwQAAQoABgUCZKo7sAAKCRDgT5vottzAEgRRD/iIGUXurEoyWkAiEM3kR6oe5kqpds0+yg4u
+9RvgQvrgA3Zl5INFvZuFtPPCz+TQ4MaFO+WfRt411TuvplFcZWVpoQ9ZUSofzBAaWeBwIlypE71h
+qOl6jON/wcM9tTgy0ZIrLONtg3pLlwdRIzD7MiB9ePCiPipypB3Ca0k7h7XC0nqg/uo6gjMo1BUG
+ZO4dzg1+5Uxm2Vj76fQyCe7I94XKVuPstp3/hftGOR5/K+T6ASAIvLAhkkiBTeEgjo2gI3hwhUTS
+K2HeF1rMpNhBPUWR/2wfZcYQ3+de8acu83LhGLjyIP+iA372vmdzZwkIjJHf/RAi0pykz9HPukz0
+gHO8bK6v+gN4BzFsJ4lR4cxsQE4cACNH7CCHydR/cmbN3bk8aVlbWOrSBBSXSVe1EOLGjKtisgNX
+y2EGU7RTT17vVph0bnzGAyjc1sl3K7lgMMtRkSm+ls09taM0YirMSd2KaogH8eU/9lmKuOoJfY8F
+T6ql4rsfHkh4s43FB+pkw9Li4pstKl8FX8KVmrQ9F59aMedVnIhAnYMz1SPhep9MtxZuvTypDzVK
+QdXq7/HUse2KIBqxPtD4d6V5v5W+mCaTuXu/FsW+++InG3qd0YQqZgyvmMeXz6yfF7uqjbUHUO7A
++NzM5O3Zpz55GyXdxSnUS3tFNVbIxMBDheCnI7aY

--- a/ubuntu-core-22-arm64-dangerous.json
+++ b/ubuntu-core-22-arm64-dangerous.json
@@ -2,13 +2,13 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-22-arm64-dangerous",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
     "timestamp": "2023-03-02T02:03:23+00:00",
     "base": "core22",
     "grade": "dangerous",
-    "storage-safety": "prefer-unencrypted",
     "snaps": [
         {
             "name": "pc",

--- a/ubuntu-core-22-arm64-dangerous.model
+++ b/ubuntu-core-22-arm64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-arm64-dangerous
@@ -27,17 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-storage-safety: prefer-unencrypted
 timestamp: 2023-03-02T02:03:23+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZAD4UAAKCRDgT5vottzAEsjZD/9ysQWYd3vLvtd3S2XbBvy35akROPgIfxTK
-ae1hUVft0ng/t7Ccql0BRShmgG4WOq1WqHlb79jDVredrS6zJrWSAHGbf6ui0eaOTRvxBtNay/1o
-xcs8vzav9+JCHdOs/4ugYmlcmxfkhH2zuIhuRpnVMW97G2Ob15dyuXlHAhgIY/aT3veY63M0CEbm
-ImsDfSt5h4YLGKr1CRnX8LKG+WXh7fF6t8KBW9MQVrQ1IhAB03vbqmxCuaRZj0NB5NvKR8XirG0B
-TqjxU+95A2MRuDUiMuyoy/DWf1RrWEgTmqCrTfpjgz4wh7jagiC9kG/x7twwJq5+PPKhHrUQoDSN
-veh233NwmzKKmGGyHYCIh6ZKEkLv1VVmfPgJrxYFYbSICof5BoKfze2qCIPY1JGIZnER+/cnkrLq
-21gZT0pgl7W90J5++LOg0rnhlS4WZgOfd7+oBjZ4nQgZ7GWMdZkmqH7ekJVaZZhGGmlYYL74TndQ
-99DSI4dC3MLmSUv+sOQukL+gHNDv3+5OL378qq7tObwE/lM1UsdhTQiXC0FS+8k5eTPQ/1Dso90l
-edhZmDgGDx+1eP0PDspW6v1SRXIPIXwKHI+OTuAZz0Hdk4A0phcHWIJybg4IVcKpukC0Xl7lrhLC
-cBN+MYUr452SrqBmcazsBP7AzWzz45+MQbjxU8l/MA==
+AcLBXAQAAQoABgUCZKo7sAAKCRDgT5vottzAEr4dEACwWDcDrqUrusEVeT28Vgh87amYfDA6DafM
+hHh46UlEFVKZzPoI9BmljLGr71NYTPbbw/4F8aIlX662lYDHgqBG5ikwJhhi7CZ1Zp9xH8f0+rny
+DywVTaWN2EDmNKxYt4a/aRy4JP0Sp1F3yunWiQC1mp5p3UTF0dYxeOJnPAlDc22nSwNDBAyeO6ZK
+9ex2PFGUQe0avbMlWavuLR+hGGCyqNKKf4jq8mvCPzZ4mLkkACXudVyekHIChjL5WWNyJBAjUM5s
+iLghjIBU/a5ykPCOSfpG4GpxrOe2zb9ViYR9b1KSNAxvlQd+MDasdqG77Pn2vtVxaDFbeyBVAy5F
+PVHuHbpnH2yPLlqJ1M5RAd/ILYdD2vVsRAE2rX8LQA+GM7+vF7NDjg8K2fR48fteTq5ektzoug8C
+zgJhbPzHQ36JfFBEs7397KFvT8dQIy9HLoiZbwy8iGohv/e18xdC//rWL/17CUWCH8rMsBQ5qp8s
+bvBaCPVo0+a13GaPaoTfmavXg43BraReKOefl85YM7hpbl2SVVKKe8Z/0slQ3m8o1bn7syFrmzcL
+JrTIR7lbmGiwg7hN2IHWwfghMg4nhLfLDKJjMwYJF6tG1f1uLUXVVUTCNacbWrgS4F9YHFgzPtAA
+UyWhwAjQ5+REWVyze61czP1pH4ha0NobsdfiQR2EVA==

--- a/ubuntu-core-22-arm64-edge.json
+++ b/ubuntu-core-22-arm64-edge.json
@@ -2,13 +2,13 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-22-arm64-edge",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
     "timestamp": "2023-03-02T02:03:23+00:00",
     "base": "core22",
     "grade": "signed",
-    "storage-safety": "prefer-unencrypted",
     "snaps": [
         {
             "name": "pc",

--- a/ubuntu-core-22-arm64-edge.model
+++ b/ubuntu-core-22-arm64-edge.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-arm64-edge
@@ -27,17 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-storage-safety: prefer-unencrypted
 timestamp: 2023-03-02T02:03:23+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZAD4UAAKCRDgT5vottzAEm8BD/91zfI+l0kNneuvpUkaGqYc7FBE8ANkODqM
-hmiPfgMyd80hLnkf9K9HTx6UAXGJc9rREqheJQLEdlYbzj7gT3k1jG7hMiXmj3fGuNZtQMqlcDTd
-JkeFSPcftAAD8giPv8COnbcPE42pE6/8Lr/h/JC3zDzyepS0S4PeQrmzqqKCIEM5p26nlpDu0AZC
-8CrX1lZffZkLhI3bwfdzidNsBS3MgVwzegdfUiSVfndjtY27BJTdHkCZSeKD3FX5U5FfQBM1gD3t
-SWhtkglrRzWj0KSem2M1/pYgo0Q9sxE/Tz3rQkB/FYOQSiBZQvswAwy3oYQs7Ten26evUor4UYlz
-AlMV/tbkbGeHC7TZI1kxZ39+e0hFeUYMPMsFGaEfICd1icZwrKouGwNoEoPPC/OQW3d4hWnsJ6cp
-hQc900ZLALpSZB1xL9jZ9XNlEEnz7fknkSbBkZE0cv+2aQIdkXh3Jya1TiKArNbJMH2mX88aw+1H
-TwJ0b8pzGjKUZ1j8WuZXPhKH+wL/XLvWxnCQWRVvf7jVVf3OXBbmNlRSqn1LyBGCQ9MnmyEgq1AV
-n+QP3TVluq7PCvP7OWrsYreFzp74Cuex84GhP7Zqx9gj0V+GrRCvYZ9JHgUIVIDqQB89vUs833Jb
-2amDKEA39pglEg1gdvyECr8r3xfw5s57Y1yPlsYHKA==
+AcLBXAQAAQoABgUCZKo7sAAKCRDgT5vottzAEvzgD/9r1un5rCsydGmfiLf+sXqSZKv/kx7lcn39
+Ca+xpjZ8vXDlV8QO9EKrCyfygKVP/vDadxAxHWImBZo9uFbvufH9r7EONm4+qjUsqlMoXQR/pa7u
+GjEUgMDK/covwWRd9YA2WfutMR6brnDpgJaL/oc8C7czuLsjtoDotBLeEIfqbun2xB3Ro2Fe/nUG
+kT7pA+I7uWQFxq+aJXmJhv5wkxAJ1aAavSRivb61HByE4Lmy0Vzr57h8ldqOeMhOTNEKG20YhdKv
+UW+3rmfeeszaTd4UHMh6tzHRAknprm1CbueJE7SCepHzg6FdtyD1CIvarfXyQqwco7LvLn0F3uxi
+DjoZOeVfPeCXBnIx1LV1oY+SI/nANLMPUCRTYNfMpa/2OBRydelVOyHFHUUhgGZIl0MgEbcF1fXN
+TSS+PLQqF7hD/kry73Nh7nmDh0DAiafXEg4QDZtufadnaEGmQm4K7p8Q25LdSbVTE72xMSemSOY+
+6Qa06jH1s0wVZf/cIQhxV/0LSnOgmpd+ne42f8QPFXDlOFJWx0Vs8ymnczc/bjbsErnkziD0KlN0
+YgDzJagLwVhIvz5YyITuEvEju1ux76sUDdooojuVqgmlJddGAcWBPnIcv3SxSDh3CMCQcMSwJOlv
+Mcn5shCWxL8EridJaU1sd6Mam3YBX18zcV1TqNS0Og==

--- a/ubuntu-core-22-arm64.json
+++ b/ubuntu-core-22-arm64.json
@@ -2,13 +2,13 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-22-arm64",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
     "timestamp": "2023-03-02T02:03:23+00:00",
     "base": "core22",
     "grade": "signed",
-    "storage-safety": "prefer-unencrypted",
     "snaps": [
         {
             "name": "pc",

--- a/ubuntu-core-22-arm64.model
+++ b/ubuntu-core-22-arm64.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-arm64
@@ -27,17 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-storage-safety: prefer-unencrypted
 timestamp: 2023-03-02T02:03:23+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZAD4UAAKCRDgT5vottzAEpUcD/4mCRxe0JP6UNhlGdI4CJJhdnKULXe8JSsd
-xKE0Pz4O5dXkhMH80KrCBuROXF7vL+3kkLoors3n2+uOnfTBIaUOavO4x2tuCzcuLCbOUx6vkWxs
-zIPIO6hiz3rkV0X0QS7RPcg/nt+dJJDKhKjPP7cR5/Nhtivv4DvSPg7jEVo3MQpV4I/YkHo/IQRh
-jTjj1wzbav00gp7ffyc2yK4fNuSisRmxnn83vNpaXmNYelPC6ZN82p5UVMVHCFmUEphk6KpbRHaP
-Su5eP241sx60ov6r0dXxmOz8/LacIkS6PqUch3+vPtWv5/tpR2f8j/hq3TNALi5uorMEjZXU/jK/
-thUIvOuBZRTrECL9iyctKqIQ+AJVW5VsL2onvaE4YhNAeJO7OWT/RRmQo3LTLhQhgZt7JlRy48Oi
-zM6741v1LZ+FoXP0e7sQCOweQAJyxbX3raK6HDl3a6df8HRAZD2vbuC5O6673Fr4BVsGRX2GbqWr
-U7aF5yLl+SXaGkpT4z3+t9EsOXzUz22KRe+dZHAhG6X061oEqrQPlXyuJJzm4VxQmAwjehZuV8M7
-PidPeO6rT4jd6cnblVRijzW2c+5ce5QTkkILKIKYgXu0U0Q0QBrjK2+gxLnGcM6KO//I8vOSRPI3
-EHe2f5/WnrV+pIsGBvYMYP6lMVRy+HhzJ++XyIfTyw==
+AcLBXAQAAQoABgUCZKo7sAAKCRDgT5vottzAElfaD/45zvti6hDX41MsEL9a7Wi+q5JY1BnaEHOX
+NkxfC9BOLui4vZLV0BzqplON6i7h67oX/GFmfA5BOv/rLNFIQA5crsMSLklBb5HG9pdHtEPEJ45/
+qPcPDDWk0iDCg0O58o87mFOMb1f3NPB4ZdoHhf+72pGiVld7yDR2T/6TxvhDgWQg+to7rh6SLMyZ
+VvW8Q+mF5M9awq63a/C+orw5I5PUhbD6zarGPQaXVLIMop+ZufDbhYiDcFKbYNvsilXOXz9lpSL5
+fcIxWKLDhW92sdGIvN+3qHCbcXCMfjNyVrwri4y7LTCa/1SyL/KKfbjP4EOB+QjacyDnuuujdKXJ
+sNFNhad2aD0MN+9w/EegA4hb1qFVcTEnlwNRcr8WfYWGd8Rns3dik9CgLk2BWaSCJNXrbTnL/dN/
+5zB5n/PB+C5hW9uTWJttpRv0RgHjJVtHnRqgXHGyiFUw41GTdAA0rhPX68xKU9MXpcyy8MwLRIs/
+I85dbIor3CDpS653/2ZLeHnTDmRceoukdrbRvG3uBBSxAzH2QhymnKlIsgDxLuhH1wRlvxTQA8f8
+BEmKsCYNIYt3xIUR52gFD1j1OXr7Fi1KyIuYKSnPfuM1k9cxOVhf64AzoPsu8ikwPe10KUpAFAE8
+OPt5R8goBpZftvnitJtblw05e0n+ZBtUDHC1CjKi1Q==


### PR DESCRIPTION
Now we support TPM backed FDE for arm64 too, so this can be removed safely.