### PR TITLE
ubuntu-classic-2310: change pc-kernel track to 23.10

### DIFF
--- a/ubuntu-classic-2310-amd64-dangerous.json
+++ b/ubuntu-classic-2310-amd64-dangerous.json
@@ -4,6 +4,7 @@
     "authority-id": "canonical",
     "brand-id": "canonical",
     "model": "ubuntu-classic-2310-amd64-dangerous",
+    "revision": "2",
     "architecture": "amd64",
     "timestamp": "2023-07-18T12:00:00.0Z",
     "base": "core22",
@@ -20,7 +21,7 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "24-hwe/edge",
+            "default-channel": "23.10/edge",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {

--- a/ubuntu-classic-2310-amd64.json
+++ b/ubuntu-classic-2310-amd64.json
@@ -4,6 +4,7 @@
     "authority-id": "canonical",
     "brand-id": "canonical",
     "model": "ubuntu-classic-2310-amd64",
+    "revision": "2",
     "architecture": "amd64",
     "timestamp": "2023-07-18T12:00:00.0Z",
     "base": "core22",
@@ -20,7 +21,7 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "24-hwe/stable",
+            "default-channel": "23.10/stable",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {


### PR DESCRIPTION
24-hwe & 23.10 have fundamentally different lifespan, GA kernel version, and userspace initrd ABI. Especially during the overall when both 23.10 and 24.04 are both stable and supported.

Use 23.10 track name as this is a strictly confined kernel snap usable for core & classic systems which are based on mantic userspace. Core systems is hypothetical, as there is no such thing as core23.10.