### PR TITLE
Fix edge models for UC24

### DIFF
--- a/ubuntu-core-24-amd64-dangerous.json
+++ b/ubuntu-core-24-amd64-dangerous.json
@@ -5,7 +5,7 @@
     "brand-id": "canonical",
     "model": "ubuntu-core-24-amd64-dangerous",
     "architecture": "amd64",
-    "timestamp": "2023-11-09T12:22:51+00:00",
+    "timestamp": "2023-12-08T12:22:51+00:00",
     "base": "core24",
     "grade": "dangerous",
     "snaps": [
@@ -18,14 +18,14 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "24/edge",
+            "default-channel": "24/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {
             "name": "core24",
             "type": "base",
             "default-channel": "latest/edge",
-            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
         },
         {
             "name": "snapd",

--- a/ubuntu-core-24-amd64-dangerous.model
+++ b/ubuntu-core-24-amd64-dangerous.model
@@ -13,13 +13,13 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 24/edge
+    default-channel: 24/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
   -
     default-channel: latest/edge
-    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
     name: core24
     type: base
   -
@@ -27,16 +27,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2023-11-09T12:22:51+00:00
+timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZUzxMwAKCRDgT5vottzAEjMZD/wMzaJGWcEtOU9WbtxKG0hJri8E2ZRXci86
-An//HUnfFHGMenJwIvTMsIFujvRjvSXOnp7MJjOTlYPg2DATOEVU6DL9+6MoVQvrApJE5+voFKsR
-aIW1Ki+65osrhRdF+P1VDSiuEPeVxtgh79rCXMr76O/yErO2bllHN0ILJhcKqBo4msx3K4/boF3g
-+WMPiPu9b1Pjz99uuoMjC5+m//+l0Bk50Ley6zZO3fwLmb6hwC1na90Xe6vbfDSgEswp/bbL/Th3
-yv7ui1LsDVojxqQLt24Mgybl29uVKCBON+nCk09mbJZW6lJD4XBETJF/b017ARtufbiWfq2pdfTj
-rVKkeNQ8ZzIwzj+mp+LyZ62N+541m2y2annyynJvlKaLs5SfdI7evvU6EwDqEF3yLoXfLuoe1Irv
-FeWUZWCkgzdFwwsCf3iJA34QTvvqf6qPfK4S4g3jipOzbmNspu2OjsEyIPZHGCKSy5hdcCaCXVZZ
-sLCIoc/WVOedfTkH6/z440OvwvccNFbt2RTAkref2oW45WWzkv0KPqPsX76IrSeje4wbmlvju2TI
-CPqFISippVutic8JBmsikK0huYmsYv0zJyVJy0Lmb4DDqJelegp0xsGy5ji7FrIikg6biTB5OG4E
-IFpDbk5A7AveonDOoSNnWCXQsXYvqx1X/pqV4EN1bA==
+AcLBXAQAAQoABgUCZW4VMwAKCRDgT5vottzAEg9qEACm06qfOsn1xfJ9ZN9IsVtoAmxrFlUaqlOr
+ZSpe6xiQWMeCYW/LsfyccLTfnyvfp4d3JBc8mjrDukUhVen8/THUFtPMuSJvI1lW9hG8z/sA5IR9
+QQGquaM+Fqqvx1ltGWsjiEPdtByxcCk/ZMJ4E2l0kT4pnhyI1lhWaRcxparSUGSn36b1WqBgi/VR
+djXbt7pD+uqN5HneJfcbprRERGV09N0iWvuTB88U4T5Ad+2MHTQhYU7Uy8gBGIidCpULTAsv41S1
+7V10qu2z0iffa4UjfMi8gYgPC49U5PzTViFY+G+GNe/b/i7J832eKO+vju7Whm0OzVH0+nnKBOHt
+uEWUsWc9QmGORBEv+NDRiCiZ4gona4G7ASJV8e/yag9GzIgr9g/0KT7BqSSJF3sJpeSag8Y257rq
+zPuCM9f90xEvjOXuvez7hykCHqxwyxcxB7EryJdeoQz1SrgkoSZDYMFnb1xG+8NgsxBXUgHJ88oU
+ekxM3sA9AIhx9+bcEdsTHCgqH35BhNqVy5VTK4RSQimlwOA17fRmoIPsBO2xZpmNxsrnCyZfCnnU
+04c60wBD88vDeFYDwRZIO4sSEj+qwNc4CPqt3BVL9ry0QA8SxxWiJByXDvx9ba12vb/mczf4bN9x
+1CRE+WWWpXszmbcHT5vrJArE5sMNDgXJoSE21ZwHrA==

--- a/ubuntu-core-24-amd64-edge.json
+++ b/ubuntu-core-24-amd64-edge.json
@@ -5,7 +5,7 @@
     "architecture": "amd64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-11-09T12:22:51+00:00",
+    "timestamp": "2023-12-08T12:22:51+00:00",
     "base": "core24",
     "grade": "signed",
     "snaps": [
@@ -18,14 +18,14 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "24/edge",
+            "default-channel": "24/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {
             "name": "core24",
             "type": "base",
             "default-channel": "latest/edge",
-            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
         },
         {
             "name": "snapd",

--- a/ubuntu-core-24-amd64-edge.model
+++ b/ubuntu-core-24-amd64-edge.model
@@ -13,13 +13,13 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 24/edge
+    default-channel: 24/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
   -
     default-channel: latest/edge
-    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
     name: core24
     type: base
   -
@@ -27,16 +27,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2023-11-09T12:22:51+00:00
+timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZUzxNAAKCRDgT5vottzAEr4yD/4zpH/ZnWZz287dIJc8H2YqL25+RB7lReD/
-kEtuXnVXDYWidTTfaU/oITCAD1GV+d/IZ2uZs3q423fxc0dv2BgNhFv/Qh645eioXDqwerSY60SV
-6cNDDfr28qVqUHivk74t9RR0pY6VzvQ20kraemJ4Hj1PbE9qMuLV7o9wKZY1WFutSMIw7d6kCul6
-CT1ERJuGUBYj9PJX9aAup+sH9xFMTnnk92/o/20QUegeYS4Vk0R4aYXantuc+G7AAZbnCsgfZ4jo
-U2GWq3N+q3IfNz95qqpqK62xyc6purBOK/OAJAZmXF2S2sZQWMlArXu/JNo5ToXutyLfcMZuPDf3
-uxUUdz7BdK0LdNBSOiDaOOkwAr+GHtiWXYNU785JZKi/nbbJGai+GKybTvNS4j2i2P7D86+fNGJa
-9dc1Ln6pBCVrki4PajhbEBbzpJjDr2KNTPjPfTphf7iDf9WY4Rev1rfeQSEOkYae26TsVaUaUkt9
-M6CJsse1nx5lq4CYVgakFBcbanpxm1DwK5BGnziHoVadWhRrGR2Dz5iTXL1npp3qQ2s+wMJCJZX4
-07OGW/mQsu+TQxn3BMe+v1tznoiYS9y4t38ArN/E1btQjVy1m6IzExy2Ex2OMZwHa2JlIUsMMtwb
-1WtVMLtxo1aB0EVdDbtBhcxTRcwLeBMdNPlSMQH6pg==
+AcLBXAQAAQoABgUCZW4VMwAKCRDgT5vottzAErVCD/0XMT7GRd+W6qIJbmBBg4t1M7up/4bbDc1s
+3SbVR/W4cjIJs4fpsPRmwFNvF8DEB6M19C1AhGSZ1tLItGrOeYRkv/V0WY676z8M/xaQBuwhTE1V
+h2UV77NXUgfNNtxwC0msTf/8/SKyywJpjmNx1CxWPfgGh6ra9bOctDGQ/vpmNRpwbnGhb52y3xry
+ttfve3iCWxKOKF3YwCij0lrmfBTdy5mwcoaIYZJV8kYJKq4MuAv/hkwAFuZqN24KaWzpxKCDKduB
+cMNw0OhVpM3NpGg0xysrj5H7fLN1Rcqd8sx+Oyo7T3PZxlk2qN0dYpsb5svrpckbVYrydyg0Y1De
+HcmHc9vy1DrrKPOMAzkjRMkbS+URW3boM3r6oZONQ9N8i/9llVrgntVXf6RqnqL7KPAUMVNw22uU
+7QrmpTMZViHekRKRhe49VKj4ck/YTQmU45rT5OSpGKkb2iRY22QkiLneDFqTV7qPnMfG+/YtY20f
+LuTGYxenKPN+YTxOhp9ualcupe5KEiumyYPuG474z6vqiLHOC17G8aQWfaO8VmSJYuTn1aqt9RWg
+jg/Ue0e+Z9T//v6CKqF5yqYdPnD76RI0KATd0mOSZb8XXuKKsO71PTQCCft1lfZP2eGObq+xS0fC
+3d8TWR8/4a7n+329BO1IGciFGjttUZefYfxgoyFs3Q==

--- a/ubuntu-core-24-arm64-dangerous.json
+++ b/ubuntu-core-24-arm64-dangerous.json
@@ -5,7 +5,7 @@
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-11-09T12:22:51+00:00",
+    "timestamp": "2023-12-08T12:22:51+00:00",
     "base": "core24",
     "grade": "dangerous",
     "snaps": [
@@ -18,14 +18,14 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "24/edge",
+            "default-channel": "24/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {
             "name": "core24",
             "type": "base",
             "default-channel": "latest/edge",
-            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
         },
         {
             "name": "snapd",

--- a/ubuntu-core-24-arm64-dangerous.model
+++ b/ubuntu-core-24-arm64-dangerous.model
@@ -13,13 +13,13 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 24/edge
+    default-channel: 24/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
   -
     default-channel: latest/edge
-    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
     name: core24
     type: base
   -
@@ -27,16 +27,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2023-11-09T12:22:51+00:00
+timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZUzxNAAKCRDgT5vottzAEgayD/9YhtpbhO/WOoHLeGOidSqRHiNfAU3d1+an
-9nworRfTLSGTuP/ADdUeUtudScYFmcXrKpx2t8umFAWywfYjQ5Hv3kDdZeuWhH1xu36Wa2Gydz++
-Ve/UCmfOt6yhUJr/mgxP2v7US2Gx7h6nqugzOAntBaTugITRSmRLWEW98QQd2Qx/+AT4kogjZrHu
-mk6JTrvIL/aW0jkqXN58RwtwdXQB4An1txRgB5o+5rxAsI2eFOO2K2QkQAFiCBh8hf49A6mk4VKL
-E50TemoCs9kKHJt4xiay5wyU4qtrzM1xFFFeiSbpb8r5h9Zxr4Q0vbkSes69V9hxMbnWuWjgHgVa
-FQ1e5k5r3WED+p9ebPDus80rnTIjtpkZ3x27j7kWQhdZqxvi9oC2GWdnVaMidHWc8TKDg2V22ebl
-CAE6hOyhhaKKEwKlhNHwgC2krp+VWn8Nc2bHTjsvwMKCyrpr79tKGYziJ/w/i/exBUaM6c3Zu8U6
-CILl6NE5fGV9kC3L31TU7d25mNHSVMPKiZIv2zq3UU2LWe3jlFQ4QZN2zxJmBhOxxhyJtOOOs+fr
-7xQEkeeDnuR48RoObEopI8OtojS1LdKj0UYW4Z9XXWoyYH75sbnV8hzxNP98f4YW1hUFhZ5IhqB2
-3AEgKVA8iTAlUgpVMJntODOp5n9t9lvSZT7obeocmw==
+AcLBXAQAAQoABgUCZW4VMwAKCRDgT5vottzAEqqMD/0cYG0CUHR3y0KaMmGAHR6Z5XrBo/Kgtfo6
+5Jcaiza2/WxLLG7iEZH2SA3uL/QfvQhbfreIMBXPwD+UTlcCu1iq52rOPaRZ8zkNT0KxTeug7gug
+C/UqU0dKx1gt4aSfgAScLc8NEPI6JGVoRwN4bqrVKr7z19ifeMmgjZatmArBxEthDwxikcfkshRj
+EM+MUznNoMS/9yXnDBhlTZlhnTcvnjFVzxeRsoE3tLJptPVggvNDMQwUm/X9FE0N4BCotCBR1Qlu
+ykm3O+zk4kbbCTefpll7Rkkh0MA1/9mYzL+M4wuovXrNGHwVdTLa2W37jSDEnspaX8sNMMYPKqBx
+Qv4qrdxJt7o1WmBXZah6tw75HxyLC/+wMQiKy6uXZhuM8mehgEGri6HWCQlwgi6g+8KHoYw8gNAU
+KJZDAexmAvxlCg/tEJ3HcLzuUxrHShD8w8u4TnH8dv4jCxNSc80HQoC1JFpjWmhq6pSsEvcCXYK6
+9HweUlEN5Pn0LEntmcecdkuWnK2Z74WvkwiWxwSUo2kZbFIm6zux/0YJ102b3Fpg5NEo4kaQ1gmx
+E6Dn4Vgccrg0ZmvylowB6efFvcLv0roz1eHW8jcd1x8xPro5pzWptI5fNrqCNg+BgzXE6sA61ay6
+eR7yzfdO9QLKJPkqO/4n4qfjF7Gg4CtoenmfMCBJPw==

--- a/ubuntu-core-24-arm64-edge.json
+++ b/ubuntu-core-24-arm64-edge.json
@@ -5,7 +5,7 @@
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-11-09T12:22:51+00:00",
+    "timestamp": "2023-12-08T12:22:51+00:00",
     "base": "core24",
     "grade": "signed",
     "snaps": [
@@ -18,14 +18,14 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "24/edge",
+            "default-channel": "24/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {
             "name": "core24",
             "type": "base",
             "default-channel": "latest/edge",
-            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
         },
         {
             "name": "snapd",

--- a/ubuntu-core-24-arm64-edge.model
+++ b/ubuntu-core-24-arm64-edge.model
@@ -13,13 +13,13 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 24/edge
+    default-channel: 24/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
   -
     default-channel: latest/edge
-    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
     name: core24
     type: base
   -
@@ -27,16 +27,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2023-11-09T12:22:51+00:00
+timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZUzxNAAKCRDgT5vottzAEmtMEACiVNzbFJ+qRNjkFOari4AwYlC7KnKX2f0C
-LlwHxrtSx4TncZnT3G2TwuN2BwR9OAO//vCnUYM0RST7qJ/whR1ZyQmvMNh6DEejGMxoUUY+UTSi
-QR7Y9Gc52Zs1pzzZ7iT2+7BtEdVBcp2TvFjx9w7B4NY93y5DB1AyZ+j5uBgdtJOgv1GOMSeqvzDs
-uWm7Tm+33hQUdiYe8UQpcEUv5bbwflvSnLYUqXqvjDIH6crRsIai2PG61Esywi4YlAIs/CNTcHsq
-XnQgzwr+nZNcnkl/xa2fgVnQ1TWVS8M4k8HNgy+jvNqBTevHE/hFC4CJQrDKyLXXpH8CljqKVV4X
-j1TtudRfT4Tgcc2eKda4S+JWNAZuuvSpSvmTxsP7ZmrQr2/+iy8w9UuGHEoVi1LzcwUyw/jHuvyk
-AXlzpez03vK/x1TfmTLSlMpDUS90t/3GMvOW3Gt/xK0WKgAz9vxjuTq1SJSImIS4hGpNyJo8H5Fl
-t6cAKx4yMrwLZacrUpYWqDDg6Kwa6lbepwD20h/2om6ZyS+Dv6oOlF1Du11RGYwcStHB1x5JsqfS
-FkytpNww86Me+gB0+LgtowoWcOivfSUJ6X5g1TecHkfgV3KLZceemTIv/1788SDVlXF1tD4xnNHG
-Fu+chAJrf6yqEvnCZLc+Yi31ufc2xdzoDXZ3ZcqVcg==
+AcLBXAQAAQoABgUCZW4VNAAKCRDgT5vottzAEm3LD/9EcjWuJ7Rs7pVy3/w2upAzWm0Vv9ZL58NA
+jEG7FRkUrEVPNJQQp3Erxe/8Xovn20JVsnXVbtX9UeCoBm82PyOZGfzxygduNNt3314Z2aBDAwJF
++MWqlw8Q9cVsekMSNAG8aFnMrYfLAG59svxejoML+N/9Lb2dRP0eLfHXNqG//dIbgjVRCPtdA5Vl
+J3QdkiuImMDsxha42NzwkmO/RcYjmKPKmRfa+ntwgEuRQJWu7qONfzqR/vYCDhQ30pF2pnzNwsNW
+Zb+gECRncI9HHao9xzqzbD9KdM24QLjYi0obIH9qMwCObHVILTnQlO4GGvg33UhwtC3zHZIPRP9V
+m3kuYyBXwWpEXGk4RUgl8PDB1GijMPmI/rd8O0AbjnaLEb1VrWSS9zDRZmX7JTo2xsaVqGQ/7Cg0
+vlGt0wNrkboflrzZ/jFG+Gz5xrcuUhsKfKL5pQvsK4lMPZYbV1vejj2RTHax9VGlR8K+BfNH2thg
+9ebgKen6mvEX7zXpFkya60d4GgBBOHDpWdDhriFbumTWb40n1YNi7U0WO9iA1xrqLnmbE6s7hRQU
+sTf2pASKIP3wjLsTtaj0ndvlSyYFyboVslRfn+meJEL1Csqry6GeBvzHBrgZOeldzbq5x7XRiSYn
+t6wt5/aQc0sz1MDB5GZOpRk042BerDjYGY8YoezkCQ==

--- a/ubuntu-core-24-pi-arm64-dangerous.json
+++ b/ubuntu-core-24-pi-arm64-dangerous.json
@@ -5,7 +5,7 @@
     "brand-id": "canonical",
     "model": "ubuntu-core-24-pi-arm64-dangerous",
     "architecture": "arm64",
-    "timestamp": "2023-11-09T12:22:51+00:00",
+    "timestamp": "2023-12-08T12:22:51+00:00",
     "base": "core24",
     "grade": "dangerous",
     "snaps": [
@@ -18,14 +18,14 @@
         {
             "name": "pi-kernel",
             "type": "kernel",
-            "default-channel": "24/edge",
+            "default-channel": "24/beta",
             "id": "jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ"
         },
         {
             "name": "core24",
             "type": "base",
             "default-channel": "latest/edge",
-            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
         },
         {
             "name": "snapd",

--- a/ubuntu-core-24-pi-arm64-dangerous.model
+++ b/ubuntu-core-24-pi-arm64-dangerous.model
@@ -13,13 +13,13 @@ snaps:
     name: pi
     type: gadget
   -
-    default-channel: 24/edge
+    default-channel: 24/beta
     id: jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ
     name: pi-kernel
     type: kernel
   -
     default-channel: latest/edge
-    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
     name: core24
     type: base
   -
@@ -27,16 +27,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2023-11-09T12:22:51+00:00
+timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZUzxNAAKCRDgT5vottzAEkTAEACrRRmbIkbtNU6RwWZafVsFKbbtzYo//yc4
-MQ505d+Vu4Cugpq3ZDM9/4piY1AkaMZymmmBKwdl0YdQkTLSDHG7fgYiCpmi7U8FnmKmNWCZSkdG
-9ucSVHScb2xTa4Wvz9Iz48nBpTTgEZc9V1qMFvDmmpOYyR2TEEzynBhek1aLX4qBDbMNPoCWpTp5
-NqQCEp02AG1xds0xxCoXQfgWaNHYcJvOgC0HaRbiuyXCmOD5a1EN6xFOCsKpbYVQDy+UBG6VjHkg
-eZqGkO5nW4vKwH6+D/8KuCTvIB1+tK6iGimwGLB7AoVN91dO5w3CvN7PnL8d7QEW3KzFm791BO3I
-4nO2ggb7Tb4RvZDxqTqdKgd4es3JK6B9zSKy3eWTPJLvjx9Y4zqKWbGn/M/CCychZ+66buCIMkmK
-/xf9/RYspZrGSzvdSacChj6O9H+0fiNt4K6sZW97WMOb6kNumNBEQPVVAH7Kp4SypQtxZZ25zgJi
-j1YS4gJDm3ev9uHbuhbs6IjPKzAIo6G2MT01LQGJqBiRn3DYs+gr8oCFwSo2oHyFFX7uNqACrAXk
-aKHRyPue3MjTPj+N4Q4OTQnl+H5sPO2GzT8ZiAdZlN8On94Rz63TaINV09f+bKICo3rg7G07nOfC
-9QvHdaZ+dih3dtutDebhVL+Vgxm+bsdB/CNdgJkjjw==
+AcLBXAQAAQoABgUCZW4VNAAKCRDgT5vottzAEvD0EACW2GN54FK8KfdeApGdoLUGbXFmWe72TEKD
+DTyr5H5EZ2YRuYkSwKzrHDi+DpjFFW+61b/LztBpbGgWjGdOrjxSXIUkTKQfLsGpHw9mzopZBfqb
+zyojuNFO3/LB/d5nrx8a89Mz/Wu/ptxqaUicTxm2uzSTFBivKjQKQfz8UjipSEUcQ3Cflvdm80Ub
+F7EF0Sf+zNpcqS6lfgLoWDbVr4J3EcYinjIQHQo7IkKAVaS/PrZ3SvmcEyWS1/6AALdiI5U/PX1B
+RBnGv9wyrMZqSRhP7rD8l8NbdVVJ4lMgLowqSDT00P0ATB2heAxqBLDnVPIiDl/N3daKerdpgcYb
+ZuuAEle3yHRSk92sDJzXIa/8us7Ib+wz2MIwDBwHDCpUo60cZPEejof9tpg9K+gW6z3sYMi1uIRI
+pH/si47VGV0idZg+s5lHoO9FmGVr3M55aBZLWM15Wod8yS+f2XojHMFI3ZLOiJfmmjCjxRgVJJvy
+Lat0Ozpuzp5H7LFa76gQdjsUpUIFDLtdep0vAjSZdz3HsWoesyChjDLfPlYGOP+kXhOsUb/IWZ3p
+woCcm/IVhR3kl/vuJRTMlXyRfc9lP7u7rR3kvBzdzTVLGXKFmplU8gjlArF4C9FKNAyWI+z6NF8f
+TnKxu1s1i5bnwdkQWLDAeV4QvOfk14NIwoULEwIrXA==

--- a/ubuntu-core-24-pi-arm64-edge.json
+++ b/ubuntu-core-24-pi-arm64-edge.json
@@ -5,7 +5,7 @@
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-11-09T12:22:51+00:00",
+    "timestamp": "2023-12-08T12:22:51+00:00",
     "base": "core24",
     "grade": "signed",
     "snaps": [
@@ -18,14 +18,14 @@
         {
             "name": "pi-kernel",
             "type": "kernel",
-            "default-channel": "24/edge",
+            "default-channel": "24/beta",
             "id": "jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ"
         },
         {
             "name": "core24",
             "type": "base",
             "default-channel": "latest/edge",
-            "id": "amcUKQILKXHHTlmSa7NMdnXSx02dNeeT"
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
         },
         {
             "name": "snapd",

--- a/ubuntu-core-24-pi-arm64-edge.model
+++ b/ubuntu-core-24-pi-arm64-edge.model
@@ -13,13 +13,13 @@ snaps:
     name: pi
     type: gadget
   -
-    default-channel: 24/edge
+    default-channel: 24/beta
     id: jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ
     name: pi-kernel
     type: kernel
   -
     default-channel: latest/edge
-    id: amcUKQILKXHHTlmSa7NMdnXSx02dNeeT
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
     name: core24
     type: base
   -
@@ -27,16 +27,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2023-11-09T12:22:51+00:00
+timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZUzxNAAKCRDgT5vottzAEpntD/90G/tqvLVb6EoUW0XV7YFLzxmAUhQgAs7/
-4CZ27+j8Vj8ZbwS/Lml/kWCTDsK6TbnbVGReUHdjQuAhvcL4PZawFf/ZZFynScLLvXfPFSirGboG
-DUUQZp8wIVbLruRPKEqdfotgfpraEhkyoX6dzGjvaRg8yFvhuSrZN6egbV0UT0RBMrehm9Jwyk10
-QklVk3W6jp8mNitIBHRbT6mRmeVGKfDa5hIKqeEr7Zx2716nbGp0FdNJNuWIRl33fzQtdFSnQKVG
-Nca6dlqwz3L+L8LpdNyELIpD/AFQVEBh/xJKtRH09mjkqOWGMMS31kHAuIAgHsSgKl6WCEIZ+H+u
-sdj2GBiUz35lwLPhk/2J8U1znwk+QyzRRrs/st3cZ6VbFW3PX6X4jC2akZ0wpyTw3Y7gdzKxOflO
-YDasYYhQAB1YEbl7kQEftaJx5wK2FF5Ga0SxFtje+LXCOFWJnt4MWfrNpRsaudERP/AoqjEn2OBV
-imoSoCJW8220NugP4XqXaN1oHRemwwe/q8/6IKziQb68k6s0T3Lnmw4HPxSO86oUr9J9X+V4svmB
-PSsCAN4E03/SD78x+uHr0Tq5tLmRpG8xAARxiXFlHw2NgKfh6dpYGYS3DTlYir+I+PdMYiUR8uZA
-tkKPwV+VV1jRJ7HGU19M32c1DqS7GQlcwhXNbNy6UA==
+AcLBXAQAAQoABgUCZW4VNAAKCRDgT5vottzAEjoyD/9Q8/HsIs1GBGd/L0CUvf6S8JG4N2yiTjFf
+mLFI18n984pixT7g8507zP8xyGUs+eMU8+6glJCBEci6S+y3gDNc1gSN6/o2Vfsw5gLf8qXE1wVb
+UC3oJ3Bfz6Rg36kYgWQx3RzYb9lrJSOco/E0wdcrzC1GPp+1MVY9nkhEz3rt2FYHaKM/X+QYBsXH
+GUDK11JbqGA1G+aEwPcmUQy786A1XnAfVmSkvh7d763MxfTf58d217zkWOzTb6cFqbomAl4mIOzD
+oxuus65fuvHMhtVi5eIuRbe6rC0Cq7tN69q6yaX4N0ydSs/NlHSPb+eIGdIJJyFfEzJzVRiNepXp
+wsUaFbV75CdmpdwYQP9veQqRxVsi1XeKz5d5BONVvIbUNIn9brauyUmxvsyLD/rcIyXCelUx9lw1
+6fOeRng/hEslzQmSEh7VJB0SGECezyzAN+5zJV2NB09WOKpHL38OEZ1xC9h6fXQPG2+1cOiY4D5H
+mpFM0p8W/eG7S8QUCm9mdo022yEzen+HNotbcnL+KI1cKX4x2em3kIQboF4WDiyE2I5azjaXBBqn
+YwHTMKShy0TTRqzkpOx4snKDDxFLUofRzuluBMNGThUK+IgAuoLflLrDbPQISp360pkseRq3bf5t
+GLPYhBq1Y+nH3KOWISqyMj/yWJMnUz2B36gWBB9apg==


### PR DESCRIPTION
The id was wrong for the core24 snap. Furthermore, change pc-kernel channel to 24/beta as edge channels are not signed with Canonical keys anymore.