### PR TITLE
ubuntu-core-24: add console-conf as optional snap

### DIFF
--- a/ubuntu-core-24-amd64-dangerous.json
+++ b/ubuntu-core-24-amd64-dangerous.json
@@ -4,8 +4,9 @@
     "authority-id": "canonical",
     "brand-id": "canonical",
     "model": "ubuntu-core-24-amd64-dangerous",
+    "revision": "2",
     "architecture": "amd64",
-    "timestamp": "2023-12-08T12:22:51+00:00",
+    "timestamp": "2024-03-12T08:42:32+00:00",
     "base": "core24",
     "grade": "dangerous",
     "snaps": [

--- a/ubuntu-core-24-amd64-dangerous.json
+++ b/ubuntu-core-24-amd64-dangerous.json
@@ -36,7 +36,7 @@
         {
             "name": "console-conf",
             "type": "app",
-            "default-channel": "latest/edge",
+            "default-channel": "24/edge",
             "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
             "presence": "optional"
         }

--- a/ubuntu-core-24-amd64-dangerous.json
+++ b/ubuntu-core-24-amd64-dangerous.json
@@ -32,6 +32,13 @@
             "type": "snapd",
             "default-channel": "latest/edge",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-24-amd64-dangerous.model
+++ b/ubuntu-core-24-amd64-dangerous.model
@@ -27,16 +27,22 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
+  -
+    default-channel: latest/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZW4VMwAKCRDgT5vottzAEg9qEACm06qfOsn1xfJ9ZN9IsVtoAmxrFlUaqlOr
-ZSpe6xiQWMeCYW/LsfyccLTfnyvfp4d3JBc8mjrDukUhVen8/THUFtPMuSJvI1lW9hG8z/sA5IR9
-QQGquaM+Fqqvx1ltGWsjiEPdtByxcCk/ZMJ4E2l0kT4pnhyI1lhWaRcxparSUGSn36b1WqBgi/VR
-djXbt7pD+uqN5HneJfcbprRERGV09N0iWvuTB88U4T5Ad+2MHTQhYU7Uy8gBGIidCpULTAsv41S1
-7V10qu2z0iffa4UjfMi8gYgPC49U5PzTViFY+G+GNe/b/i7J832eKO+vju7Whm0OzVH0+nnKBOHt
-uEWUsWc9QmGORBEv+NDRiCiZ4gona4G7ASJV8e/yag9GzIgr9g/0KT7BqSSJF3sJpeSag8Y257rq
-zPuCM9f90xEvjOXuvez7hykCHqxwyxcxB7EryJdeoQz1SrgkoSZDYMFnb1xG+8NgsxBXUgHJ88oU
-ekxM3sA9AIhx9+bcEdsTHCgqH35BhNqVy5VTK4RSQimlwOA17fRmoIPsBO2xZpmNxsrnCyZfCnnU
-04c60wBD88vDeFYDwRZIO4sSEj+qwNc4CPqt3BVL9ry0QA8SxxWiJByXDvx9ba12vb/mczf4bN9x
-1CRE+WWWpXszmbcHT5vrJArE5sMNDgXJoSE21ZwHrA==
+AcLBXAQAAQoABgUCZdeFgAAKCRDgT5vottzAEvJBD/sEdGH4f33ZPWsJHmyuCL8n5QGVdI8X+PFx
+0oFA489ljbXXxhOrRO39tMKQBumY21lJGnO/Nz2wOoCNvDGb+5PdkRgZrJhekzxM9Va01qFSB/dA
+Dv2VaHyhnQUeWPpszFAKdzVISXScRx1Bk+0fyHEs8pmOr6WAggS5R7nEJqfhfmVa6z1cuu+iXpVm
+ZJ2/s0PQaPKiN99Ye9CBB+4YrSLMrk+6IaoX+pEBOLaNwLGgFrnWOyqe1y1VUpXMZ8D1kvRFJFAu
+ZfAA2h5Hr7n1G3shY/CW0Y5aleqEhE+XhyjoalI2dfZQW+AuvFATQ9rbsymq4ve6krmSoKGN9kKi
+KWG4WmA8PYR2W0GoV6D/+qY49IZHjohLJ0st2dx+daHlwqx3OF2BMaUywP+mKuR15DhUjwnDxE7q
+QzpqGdqd0BIZrsmiJU/XtXe/m5t/VbyjIaybyeLKsGbpV3w+UHvB+OfeDU+ibk3bEQXLtkmm/tYh
+SQMjNAN3s0GK1IbPgpZITQZTjzG6m8s46zWIoPVUBN6CoWbtzdnPxvnVvJv1KshJ4bfiRMoi6R5s
+ture4nI8/nkD9aeqHioPFnS/joCo6v6PAIu0iI7GmIYx/E8Q7R+0j5g0In7JAEPN3Um0pE09pv0p
+L/uOIu26aHjSsUSS1f+SQaG/q0dskB+8pwsLde/yhw==

--- a/ubuntu-core-24-amd64-dangerous.model
+++ b/ubuntu-core-24-amd64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-24-amd64-dangerous
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2023-12-08T12:22:51+00:00
+timestamp: 2024-03-12T08:42:32+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEiddEACPNqpI/9kNYSmvVoIeL181vM7lO/E7pTct
-HR8sSU2Ryw0EGnzzVlNDTyM3fDvil1bZeyKKperDn1efDcf8epGMCt8TNcMWsboD+V4ZNdDAY2bN
-z/Tc9Obrk6Aow44AZUUJXM4vJfnDBZQk/BTZPrujt92nSHXzzAKQXIgrlh0U3mx27aJpavn5K+Jt
-6h6OPARys28Q75MMDOw0ORqm0cMkbvgzBPtfxdVyiYIyswGf2j39M0omZTnlPX/eQqe/ze1L22u4
-EZkRbMH17A8u0kPx0pXzd58SG5RcSd6E6bETBDVr1olEf7lrtTsSZBEenFrbxZCvwD91vqrtAaO+
-FBABjMfw+k4amXY2rDxAGUFcFURjoF4IrN7x4Eau7Mnu5Odh7z+y9wjE090/ChZOjYzGkNdrl4MR
-yPJo06vZNPZ5k7hoSOgJG0StCKJwGAqF/ERCz8QhSmIDKgbxD8gP4ueEb9DnGEW6ZMI1vCsTG3WM
-knZ9gdaH7JB4YyThOMfXw08fW+49WcrrTJp0vcsP5Yj77V5XMAdpUhSzWP4DUWACtkXySDUxNEP8
-i6eZivlozVVThanGdXv1q0SYK6oHxYhSpk4mLk/8436bVhiewycPyveHLuBC+vyoa/boyiQ0s3TZ
-jTODZw6Pn/G/DYZmjhpZUonpislf/ucpAZQ7MTGf9Q==
+AcLBXAQAAQoABgUCZfBvFgAKCRDgT5vottzAEkUZD/9q2UjBGOMNUaAOqpSxtAwgKGtt1uVYE74d
+5U3V+gqHC5x6eSdXkm6DCbHPp54Lxz3f4so2Epp8lYGyrtUPJdXmP57w49BvMZfItudSto8IPkdZ
+ogYYZQfaV5L0JUL+OEdrOlbuUEWkHAbqxKrFHlv5c3VwlzaplQixTenyvfAxsERJSgrRUaz1FuL/
+AuoWkz4hpvDe1JV+mLyHmaqea8U9g+H7gd5x5pSI/f6S2t1Ercds3fDe8Ot92E2vsi5PhOC/z5mn
+MS2Lv7KYKXMIMvOfh2GzV2cv2ZPjPv/D8lJ/y4BCl4N1iUmUb52fW6m3Whdi/LqDM0VkSvJXWX23
+H+szcnq09EM4ajcuXxUGVl9Z0QeQG9goKFRqF0lTfMo2EIGkOvWbO077SjzWWpFfr7GtB74J9xu3
+RgxDPmk0HEdYy4u7jUAiOpIMytmKiCor7hXCnMUvadP//slpnH2Pi5nqq0bm32nID6JjBjYO3IrL
+TuuSaKbjGpyHIGg/dUBZltHtsgGgRxF7CFrtzxhGjdIg8tllG6nMdPm9G3Vsic9zuBG8uLAOX7Dr
+RvT5/ylHYnbE68Y6TQJGhfH1qYpbqnG3QTJX8bDDHJ4nBKyNhBdrZQ2wOvBOLnyN9npaJO83qpF6
+Xv/6BUbwNtOnPL3ovnBLe1RJ358a7TcUtfuES1XlyQ==

--- a/ubuntu-core-24-amd64-dangerous.model
+++ b/ubuntu-core-24-amd64-dangerous.model
@@ -28,7 +28,7 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: 24/edge
     id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
     name: console-conf
     presence: optional
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZdeFgAAKCRDgT5vottzAEvJBD/sEdGH4f33ZPWsJHmyuCL8n5QGVdI8X+PFx
-0oFA489ljbXXxhOrRO39tMKQBumY21lJGnO/Nz2wOoCNvDGb+5PdkRgZrJhekzxM9Va01qFSB/dA
-Dv2VaHyhnQUeWPpszFAKdzVISXScRx1Bk+0fyHEs8pmOr6WAggS5R7nEJqfhfmVa6z1cuu+iXpVm
-ZJ2/s0PQaPKiN99Ye9CBB+4YrSLMrk+6IaoX+pEBOLaNwLGgFrnWOyqe1y1VUpXMZ8D1kvRFJFAu
-ZfAA2h5Hr7n1G3shY/CW0Y5aleqEhE+XhyjoalI2dfZQW+AuvFATQ9rbsymq4ve6krmSoKGN9kKi
-KWG4WmA8PYR2W0GoV6D/+qY49IZHjohLJ0st2dx+daHlwqx3OF2BMaUywP+mKuR15DhUjwnDxE7q
-QzpqGdqd0BIZrsmiJU/XtXe/m5t/VbyjIaybyeLKsGbpV3w+UHvB+OfeDU+ibk3bEQXLtkmm/tYh
-SQMjNAN3s0GK1IbPgpZITQZTjzG6m8s46zWIoPVUBN6CoWbtzdnPxvnVvJv1KshJ4bfiRMoi6R5s
-ture4nI8/nkD9aeqHioPFnS/joCo6v6PAIu0iI7GmIYx/E8Q7R+0j5g0In7JAEPN3Um0pE09pv0p
-L/uOIu26aHjSsUSS1f+SQaG/q0dskB+8pwsLde/yhw==
+AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEiddEACPNqpI/9kNYSmvVoIeL181vM7lO/E7pTct
+HR8sSU2Ryw0EGnzzVlNDTyM3fDvil1bZeyKKperDn1efDcf8epGMCt8TNcMWsboD+V4ZNdDAY2bN
+z/Tc9Obrk6Aow44AZUUJXM4vJfnDBZQk/BTZPrujt92nSHXzzAKQXIgrlh0U3mx27aJpavn5K+Jt
+6h6OPARys28Q75MMDOw0ORqm0cMkbvgzBPtfxdVyiYIyswGf2j39M0omZTnlPX/eQqe/ze1L22u4
+EZkRbMH17A8u0kPx0pXzd58SG5RcSd6E6bETBDVr1olEf7lrtTsSZBEenFrbxZCvwD91vqrtAaO+
+FBABjMfw+k4amXY2rDxAGUFcFURjoF4IrN7x4Eau7Mnu5Odh7z+y9wjE090/ChZOjYzGkNdrl4MR
+yPJo06vZNPZ5k7hoSOgJG0StCKJwGAqF/ERCz8QhSmIDKgbxD8gP4ueEb9DnGEW6ZMI1vCsTG3WM
+knZ9gdaH7JB4YyThOMfXw08fW+49WcrrTJp0vcsP5Yj77V5XMAdpUhSzWP4DUWACtkXySDUxNEP8
+i6eZivlozVVThanGdXv1q0SYK6oHxYhSpk4mLk/8436bVhiewycPyveHLuBC+vyoa/boyiQ0s3TZ
+jTODZw6Pn/G/DYZmjhpZUonpislf/ucpAZQ7MTGf9Q==

--- a/ubuntu-core-24-amd64-edge.json
+++ b/ubuntu-core-24-amd64-edge.json
@@ -2,10 +2,11 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-24-amd64-edge",
+    "revision": "2",
     "architecture": "amd64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-12-08T12:22:51+00:00",
+    "timestamp": "2024-03-12T08:42:32+00:00",
     "base": "core24",
     "grade": "signed",
     "snaps": [

--- a/ubuntu-core-24-amd64-edge.json
+++ b/ubuntu-core-24-amd64-edge.json
@@ -36,7 +36,7 @@
         {
             "name": "console-conf",
             "type": "app",
-            "default-channel": "latest/edge",
+            "default-channel": "24/edge",
             "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
             "presence": "optional"
         }

--- a/ubuntu-core-24-amd64-edge.json
+++ b/ubuntu-core-24-amd64-edge.json
@@ -32,6 +32,13 @@
             "type": "snapd",
             "default-channel": "latest/edge",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-24-amd64-edge.model
+++ b/ubuntu-core-24-amd64-edge.model
@@ -28,7 +28,7 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: 24/edge
     id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
     name: console-conf
     presence: optional
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEl29EACzq1s+uXLNs/MpiTptH4xhLXvVZIxNwM7J
-uXvFwjkGtYTIUevdGY9ryKd4NwGeTyEsznsJwxamkMPb5okFVLq5bxVlG9rn/KFyIi/xI1IjT1/+
-kSIwiempwAL7HwqHVVa/PAWhlOIx6tWXvBkF4vjMdCbCstPniSRYVU7YqI7Yz2ruKTYjsrlBNHBW
-dbYELfy6dCc/W9YILkvaEWFnkBCBRHJmx8EQ96aDqxcg8RKWh/FQneczAZY+L6v2pPj8kj8Qz7fu
-oNTvbkClYYoyYYCFp786RpSLY1qLCX5OTfWBKDEHJDKCGyhF1mjQ8e+uOtRWZYAK3BoDYOHcAe+u
-iRSKDqteZcUHWwPeY5aIzwuaff9T9BqiY902SZ9ZPcI6nbI2Ois25vTa3e4vWcQXE0KtMdrunyo9
-hLr7eHXbU0z1zhIfF0AlQS6YpD/iEeYVAzGVNX+q64y17JRQQiU4u3TYDtSONHnvGPiDiPiY9Vs/
-FS4nTd1qhhDG11DSjrO4jIgc+sEcCxvo6zQgUOdi1a/1wSKAX6VbOf+leXnhXPkbd3Ku0jLxZwch
-lEv86JlMpUR+S7g96jqQQVdqu2VgGcRxl4VODZA7pTVuxzcalH/LXjHHZlaULpC6Dn21nR81LnQ8
-DW0jqOCKdU+FsUP6mcATxcZhyIMOZ0TOGPprVZZxnQ==
+AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEqIgD/oDCCFTaezGdY3wW+cE5PrG4w3A7Tgxb9ul
+pjbCfB+P66WJMX3+SVxAjLpDcnF2PmqlGgmVsqYyedstMXPPeqzBavFFIE9oblabPBkNaCjX+hTw
+ugw1RFszXO/hr1XrhOXsgf4ViqBwc7LOUYEsW2F8z3lkQSeqb9FUJRvq75WxuNYffJodIg+1bZV7
+tLDbsctgeLGpIpT6e+5nqw9nO0iDUJbejzQEp7yzf+iE6ILs/P9++oZ1bDFuXrBWtT7lirV85W2v
+1ZxwH/52MPoaaedMigW2dYqnm54okwRnxIjgxHDJeaWfCGMD5EOPWccXzQYhmzlAPV3lxmHmJYRj
+fSWVPX1Kr/lDmKE8prRhky8fdxwU2+zTjGOORgnr8E/GhpuzGDxjKl/1vl6cfOLykZq5HaqbPunt
+LXYKwIskfxWUPAy1NRkX/wr+hCeraxc9Wlq0X4I/worJs7hib0Xt/QiAHUI7z+4lBwwAPGGr/aBF
+b9gQp2s+xvT5iigJO29gb+rdLa4h5hP58XM6/7PiWNDhADQOQ7IBdgFKgSP0WnRyN+EuGT1IWlsc
+ZLbPB9IIawtZGnBQSnds+R4EG8O8PeDBOOD3x6IdI/A66ges0h28e1e9eIvlRvgIojTujqDivBxS
+kDk6ndwOiK5zTR1f/q1nWYWNmLFFWb4kLY8MAb1Gdg==

--- a/ubuntu-core-24-amd64-edge.model
+++ b/ubuntu-core-24-amd64-edge.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-24-amd64-edge
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2023-12-08T12:22:51+00:00
+timestamp: 2024-03-12T08:42:32+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEqIgD/oDCCFTaezGdY3wW+cE5PrG4w3A7Tgxb9ul
-pjbCfB+P66WJMX3+SVxAjLpDcnF2PmqlGgmVsqYyedstMXPPeqzBavFFIE9oblabPBkNaCjX+hTw
-ugw1RFszXO/hr1XrhOXsgf4ViqBwc7LOUYEsW2F8z3lkQSeqb9FUJRvq75WxuNYffJodIg+1bZV7
-tLDbsctgeLGpIpT6e+5nqw9nO0iDUJbejzQEp7yzf+iE6ILs/P9++oZ1bDFuXrBWtT7lirV85W2v
-1ZxwH/52MPoaaedMigW2dYqnm54okwRnxIjgxHDJeaWfCGMD5EOPWccXzQYhmzlAPV3lxmHmJYRj
-fSWVPX1Kr/lDmKE8prRhky8fdxwU2+zTjGOORgnr8E/GhpuzGDxjKl/1vl6cfOLykZq5HaqbPunt
-LXYKwIskfxWUPAy1NRkX/wr+hCeraxc9Wlq0X4I/worJs7hib0Xt/QiAHUI7z+4lBwwAPGGr/aBF
-b9gQp2s+xvT5iigJO29gb+rdLa4h5hP58XM6/7PiWNDhADQOQ7IBdgFKgSP0WnRyN+EuGT1IWlsc
-ZLbPB9IIawtZGnBQSnds+R4EG8O8PeDBOOD3x6IdI/A66ges0h28e1e9eIvlRvgIojTujqDivBxS
-kDk6ndwOiK5zTR1f/q1nWYWNmLFFWb4kLY8MAb1Gdg==
+AcLBXAQAAQoABgUCZfBvFgAKCRDgT5vottzAEuRDD/9x+W4M1ed7TpcDBHzcGm9b6RR/jDZk0Vm5
+3ZwsS1EFtqxUrxaHVBicceVOjcapPVq9frkVy4b/2tdx6AD+7TJMyVJm36lyANB5hOiBsVTYijhv
+MX5Pw6V0wzMmUk9kuTcGh80GPB3oG3vbJndbf3BN0tubwlYpTat1pDkG3pMpkCrwcmtNTgN7DZb5
+7k8/sPxNLqOlOxBNKafBPYtWrtE4pnSGkUbgchW7DSumikicZLmMdGysD7/Oye3SrKfAhLtljv1F
+puIttmiirk9n+Bl9L929H7tSX/TasnyfUq5F0LJqkj5VddNtK6R3fujs1h34tCM53/Yf0W3JtkP/
+izHq21DVg0K3gAwXjshSAeZ5p4CCIWnm2OWkdp+hF3fX9bBwYKGWKmEhd0vC46j6qSj7ubk/Mz+A
+oM2hbbwxkMAfVdWiXpWrcSN/KNUyzDvtFTM9caaDs48J/MzwE6FV6uTfe4YlPDkgmzW8erO5E3JB
+IZNPGuRQBXkFHOQtsxgVkS4YLfkmUpdiHcZyJjrhB2kDhWWTJt9cl4MJvEknHveOo9i3XcBjIvDW
+etFfR8HVDMmYaq3oRyOmVRD1BtikmdujosfWRi/KNg5e533GDRl4eN3GHQHnflqfgqZzsGbFGVvl
+Drkh0309PbFSLx/3onmDzL5B6rwRvQObv90GWbHbPQ==

--- a/ubuntu-core-24-amd64-edge.model
+++ b/ubuntu-core-24-amd64-edge.model
@@ -27,16 +27,22 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
+  -
+    default-channel: latest/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZW4VMwAKCRDgT5vottzAErVCD/0XMT7GRd+W6qIJbmBBg4t1M7up/4bbDc1s
-3SbVR/W4cjIJs4fpsPRmwFNvF8DEB6M19C1AhGSZ1tLItGrOeYRkv/V0WY676z8M/xaQBuwhTE1V
-h2UV77NXUgfNNtxwC0msTf/8/SKyywJpjmNx1CxWPfgGh6ra9bOctDGQ/vpmNRpwbnGhb52y3xry
-ttfve3iCWxKOKF3YwCij0lrmfBTdy5mwcoaIYZJV8kYJKq4MuAv/hkwAFuZqN24KaWzpxKCDKduB
-cMNw0OhVpM3NpGg0xysrj5H7fLN1Rcqd8sx+Oyo7T3PZxlk2qN0dYpsb5svrpckbVYrydyg0Y1De
-HcmHc9vy1DrrKPOMAzkjRMkbS+URW3boM3r6oZONQ9N8i/9llVrgntVXf6RqnqL7KPAUMVNw22uU
-7QrmpTMZViHekRKRhe49VKj4ck/YTQmU45rT5OSpGKkb2iRY22QkiLneDFqTV7qPnMfG+/YtY20f
-LuTGYxenKPN+YTxOhp9ualcupe5KEiumyYPuG474z6vqiLHOC17G8aQWfaO8VmSJYuTn1aqt9RWg
-jg/Ue0e+Z9T//v6CKqF5yqYdPnD76RI0KATd0mOSZb8XXuKKsO71PTQCCft1lfZP2eGObq+xS0fC
-3d8TWR8/4a7n+329BO1IGciFGjttUZefYfxgoyFs3Q==
+AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEl29EACzq1s+uXLNs/MpiTptH4xhLXvVZIxNwM7J
+uXvFwjkGtYTIUevdGY9ryKd4NwGeTyEsznsJwxamkMPb5okFVLq5bxVlG9rn/KFyIi/xI1IjT1/+
+kSIwiempwAL7HwqHVVa/PAWhlOIx6tWXvBkF4vjMdCbCstPniSRYVU7YqI7Yz2ruKTYjsrlBNHBW
+dbYELfy6dCc/W9YILkvaEWFnkBCBRHJmx8EQ96aDqxcg8RKWh/FQneczAZY+L6v2pPj8kj8Qz7fu
+oNTvbkClYYoyYYCFp786RpSLY1qLCX5OTfWBKDEHJDKCGyhF1mjQ8e+uOtRWZYAK3BoDYOHcAe+u
+iRSKDqteZcUHWwPeY5aIzwuaff9T9BqiY902SZ9ZPcI6nbI2Ois25vTa3e4vWcQXE0KtMdrunyo9
+hLr7eHXbU0z1zhIfF0AlQS6YpD/iEeYVAzGVNX+q64y17JRQQiU4u3TYDtSONHnvGPiDiPiY9Vs/
+FS4nTd1qhhDG11DSjrO4jIgc+sEcCxvo6zQgUOdi1a/1wSKAX6VbOf+leXnhXPkbd3Ku0jLxZwch
+lEv86JlMpUR+S7g96jqQQVdqu2VgGcRxl4VODZA7pTVuxzcalH/LXjHHZlaULpC6Dn21nR81LnQ8
+DW0jqOCKdU+FsUP6mcATxcZhyIMOZ0TOGPprVZZxnQ==

--- a/ubuntu-core-24-arm64-dangerous.json
+++ b/ubuntu-core-24-arm64-dangerous.json
@@ -36,7 +36,7 @@
         {
             "name": "console-conf",
             "type": "app",
-            "default-channel": "latest/edge",
+            "default-channel": "24/edge",
             "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
             "presence": "optional"
         }

--- a/ubuntu-core-24-arm64-dangerous.json
+++ b/ubuntu-core-24-arm64-dangerous.json
@@ -2,10 +2,11 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-24-arm64-dangerous",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-12-08T12:22:51+00:00",
+    "timestamp": "2024-03-12T08:42:32+00:00",
     "base": "core24",
     "grade": "dangerous",
     "snaps": [

--- a/ubuntu-core-24-arm64-dangerous.json
+++ b/ubuntu-core-24-arm64-dangerous.json
@@ -32,6 +32,13 @@
             "type": "snapd",
             "default-channel": "latest/edge",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-24-arm64-dangerous.model
+++ b/ubuntu-core-24-arm64-dangerous.model
@@ -27,16 +27,22 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
+  -
+    default-channel: latest/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZW4VMwAKCRDgT5vottzAEqqMD/0cYG0CUHR3y0KaMmGAHR6Z5XrBo/Kgtfo6
-5Jcaiza2/WxLLG7iEZH2SA3uL/QfvQhbfreIMBXPwD+UTlcCu1iq52rOPaRZ8zkNT0KxTeug7gug
-C/UqU0dKx1gt4aSfgAScLc8NEPI6JGVoRwN4bqrVKr7z19ifeMmgjZatmArBxEthDwxikcfkshRj
-EM+MUznNoMS/9yXnDBhlTZlhnTcvnjFVzxeRsoE3tLJptPVggvNDMQwUm/X9FE0N4BCotCBR1Qlu
-ykm3O+zk4kbbCTefpll7Rkkh0MA1/9mYzL+M4wuovXrNGHwVdTLa2W37jSDEnspaX8sNMMYPKqBx
-Qv4qrdxJt7o1WmBXZah6tw75HxyLC/+wMQiKy6uXZhuM8mehgEGri6HWCQlwgi6g+8KHoYw8gNAU
-KJZDAexmAvxlCg/tEJ3HcLzuUxrHShD8w8u4TnH8dv4jCxNSc80HQoC1JFpjWmhq6pSsEvcCXYK6
-9HweUlEN5Pn0LEntmcecdkuWnK2Z74WvkwiWxwSUo2kZbFIm6zux/0YJ102b3Fpg5NEo4kaQ1gmx
-E6Dn4Vgccrg0ZmvylowB6efFvcLv0roz1eHW8jcd1x8xPro5pzWptI5fNrqCNg+BgzXE6sA61ay6
-eR7yzfdO9QLKJPkqO/4n4qfjF7Gg4CtoenmfMCBJPw==
+AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEoEvD/oCW3cjLb03CwmNq82vwgu4+rBNBizgQAMw
+Np+BSn6nAzGD+/m9SJ2Ay76PKFlV2xeh3kx3aQeNJ45LaQ0zJn7QAEPrEWDN49G9lEiw5A4vpNhT
+L+Cu5oIrf90dph70u2KiR/0fyQl6loPjSQcZAaSNLMos9QDg0qxjL4QS6mjTrfLjfCBmHXynXFWQ
+4r11BAkprvDftVdLwP8QgFVBs/93XBJAyYAOcIilPkSXCYQ4bPYyoQxr5dTBkzKzfziA3NQ+gqqJ
+Qu6iD4j/LPD+HZQvc5mwQs+tr2btlYMKk8ugtBD+Btg95aoe00P8ZU0vV2RygXVVw3cEo6cs8Qkk
+tfR2d42+cjbxhStqdiH2TWXnx8rj7Rnfrss5IgZ7p5O9Y8l5OnzaKVivogk1cjlbqjvj8oKw7HrK
+WByWwN56DL9Ve33UJzvJl1YI+wOdlAEnZZtrhC8FGTzRkHQGVhorLsavyYrN802Pq5Ju5MRu1L+W
+DasuRIxRMQzT9K6qjY0Jr0te61RdC3ANkKNSjm+N2TlxpbDbeuh98weJzji3JAyJ/mY5tan6eMFt
+PVaTNOtXYAvBrz6AhVfiLS2mx/0pR8IFtOpb0O/Bq4l1ljvxagtPg4TE/Q5aso1JTSxrQRwnAZH7
+yjQB9Uy3P9rCv16fbmL2Tt45cZl/kW1d3Tv87Yhp7g==

--- a/ubuntu-core-24-arm64-dangerous.model
+++ b/ubuntu-core-24-arm64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-24-arm64-dangerous
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2023-12-08T12:22:51+00:00
+timestamp: 2024-03-12T08:42:32+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEl8BD/4moGgoMU7smRmlXYU7u8QSWCjkOjVQS5o7
-oB4aFiP60nQCW6Dl/tFJJ2l3HxXikCVv8Y3EDmWa/3mY1eQT1JT6wbt1/WZY3vzgbaI/RoPnod5X
-DrUA8bU0YVN51n3sqLDV/rm6+aG1ssScsijWb745B1c128cT/dO8Kt9HRHf8EWWv1k2PCjVqnLlp
-uN6T/ih+7Sc0CbD0H3+pn9FIRRERo1FlGloWBl3XYIYHMsj6RoMpMQdhI4x/vjFe1YPMHx0oqsgF
-hveCghf8UrjtLyWPPuTvhslM897yfkzXZvdnVGgcJfrShOozmJ8Tb8m5tU6eHGTPas9AUpTYkB3G
-aAOxhFnPM6q6hy/keg4s+7JA9INrfmbGCxavqQDbVWPCaLErVcVTO0XZTgfbS6rFIVxl6fZTkywq
-hsnGh6PmjQCJzICtKRmxb1p+kWyoBEJ37BRhshD62+sB0kKY5HCSKNlBW/Ceq6rwY44thCVMWdhj
-qtoPqolXgbbSY6SBBEITCEX01jIHAccG4ovi6vBa6slyV52YIuc6v1XgnR4fsLtIbWdk3mm8BvRX
-Ws2LemcDKB+up85404wqZbLdVxUagvYBpWzqGd5mFB7b0N+HjKU9PmcT6Y4rKlPySdGmxCWMZtLw
-ORIpgpoq2f0qAUImu17DPUdqQj2hDEBF4umK0/gFbg==
+AcLBXAQAAQoABgUCZfBvFgAKCRDgT5vottzAEu+UEACCbKOMYbKqy1SGIJNT/iKrgIxxJfHjynvy
+1i0gW9GAezCVzblimXkJfiUM/QFrng8PXyt1KEbyxkGbYnqpCcb0wfYfnRrHlWio71E/+vZSWAIh
+z/e/fheL7FbNtZj98yjn5OP6IHwFtoxWSLnUAO3Y/WPIY3ziCMHn4iDc1D5riGgZUjSRtzUWYMe1
+m9fZCEjhBshNgI/CXDRP0nCzr6szQ2Q6SRGPgD9pY3jVfias4nOUCwMjatQQijVB3jn0LHWmCbtv
+w+92RiroduK4EzTbeAJfXnqborVB3su/LAs2vEbv3id+CmEkhE6UwT9/YA1qOKLytU4Mcq8+e0Dl
+gyFfcQWjBAiYupia1EGczeHRtOgM+/gPj9arc1swmVlDwDfEJIEmRX6oY6MEXTyRo7g3A7hQXBM7
+WKjWfBtkQhL41ruq0jF9CeLJw1MmLiE1z0cl3hMpgveNbBc2CMEL0bgbUU2w8HziTQ3pu3yWa4r1
+r7ifmb7A4Agmt8CJf8KIG/XKuwTtFSQkxtAtYd8ePTfWVn/Y+Od4rXHRP5rZqw5ivQh+zBVBhlCq
+jYLJGf95S/xSnmNmKcsOTRUnysYH3VHIlgKsxxtH5IO80PWRDhJ+y9XgRJ0L0P4MC5ZB2Ul7rw8z
+64jjS+GOjmTMj22AtMyDI4iGRBQVhAcsAJwU2hZwaQ==

--- a/ubuntu-core-24-arm64-dangerous.model
+++ b/ubuntu-core-24-arm64-dangerous.model
@@ -28,7 +28,7 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: 24/edge
     id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
     name: console-conf
     presence: optional
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEoEvD/oCW3cjLb03CwmNq82vwgu4+rBNBizgQAMw
-Np+BSn6nAzGD+/m9SJ2Ay76PKFlV2xeh3kx3aQeNJ45LaQ0zJn7QAEPrEWDN49G9lEiw5A4vpNhT
-L+Cu5oIrf90dph70u2KiR/0fyQl6loPjSQcZAaSNLMos9QDg0qxjL4QS6mjTrfLjfCBmHXynXFWQ
-4r11BAkprvDftVdLwP8QgFVBs/93XBJAyYAOcIilPkSXCYQ4bPYyoQxr5dTBkzKzfziA3NQ+gqqJ
-Qu6iD4j/LPD+HZQvc5mwQs+tr2btlYMKk8ugtBD+Btg95aoe00P8ZU0vV2RygXVVw3cEo6cs8Qkk
-tfR2d42+cjbxhStqdiH2TWXnx8rj7Rnfrss5IgZ7p5O9Y8l5OnzaKVivogk1cjlbqjvj8oKw7HrK
-WByWwN56DL9Ve33UJzvJl1YI+wOdlAEnZZtrhC8FGTzRkHQGVhorLsavyYrN802Pq5Ju5MRu1L+W
-DasuRIxRMQzT9K6qjY0Jr0te61RdC3ANkKNSjm+N2TlxpbDbeuh98weJzji3JAyJ/mY5tan6eMFt
-PVaTNOtXYAvBrz6AhVfiLS2mx/0pR8IFtOpb0O/Bq4l1ljvxagtPg4TE/Q5aso1JTSxrQRwnAZH7
-yjQB9Uy3P9rCv16fbmL2Tt45cZl/kW1d3Tv87Yhp7g==
+AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEl8BD/4moGgoMU7smRmlXYU7u8QSWCjkOjVQS5o7
+oB4aFiP60nQCW6Dl/tFJJ2l3HxXikCVv8Y3EDmWa/3mY1eQT1JT6wbt1/WZY3vzgbaI/RoPnod5X
+DrUA8bU0YVN51n3sqLDV/rm6+aG1ssScsijWb745B1c128cT/dO8Kt9HRHf8EWWv1k2PCjVqnLlp
+uN6T/ih+7Sc0CbD0H3+pn9FIRRERo1FlGloWBl3XYIYHMsj6RoMpMQdhI4x/vjFe1YPMHx0oqsgF
+hveCghf8UrjtLyWPPuTvhslM897yfkzXZvdnVGgcJfrShOozmJ8Tb8m5tU6eHGTPas9AUpTYkB3G
+aAOxhFnPM6q6hy/keg4s+7JA9INrfmbGCxavqQDbVWPCaLErVcVTO0XZTgfbS6rFIVxl6fZTkywq
+hsnGh6PmjQCJzICtKRmxb1p+kWyoBEJ37BRhshD62+sB0kKY5HCSKNlBW/Ceq6rwY44thCVMWdhj
+qtoPqolXgbbSY6SBBEITCEX01jIHAccG4ovi6vBa6slyV52YIuc6v1XgnR4fsLtIbWdk3mm8BvRX
+Ws2LemcDKB+up85404wqZbLdVxUagvYBpWzqGd5mFB7b0N+HjKU9PmcT6Y4rKlPySdGmxCWMZtLw
+ORIpgpoq2f0qAUImu17DPUdqQj2hDEBF4umK0/gFbg==

--- a/ubuntu-core-24-arm64-edge.json
+++ b/ubuntu-core-24-arm64-edge.json
@@ -2,10 +2,11 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-24-arm64-edge",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-12-08T12:22:51+00:00",
+    "timestamp": "2024-03-12T08:42:32+00:00",
     "base": "core24",
     "grade": "signed",
     "snaps": [

--- a/ubuntu-core-24-arm64-edge.json
+++ b/ubuntu-core-24-arm64-edge.json
@@ -36,7 +36,7 @@
         {
             "name": "console-conf",
             "type": "app",
-            "default-channel": "latest/edge",
+            "default-channel": "24/edge",
             "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
             "presence": "optional"
         }

--- a/ubuntu-core-24-arm64-edge.json
+++ b/ubuntu-core-24-arm64-edge.json
@@ -32,6 +32,13 @@
             "type": "snapd",
             "default-channel": "latest/edge",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-24-arm64-edge.model
+++ b/ubuntu-core-24-arm64-edge.model
@@ -27,16 +27,22 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
+  -
+    default-channel: latest/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZW4VNAAKCRDgT5vottzAEm3LD/9EcjWuJ7Rs7pVy3/w2upAzWm0Vv9ZL58NA
-jEG7FRkUrEVPNJQQp3Erxe/8Xovn20JVsnXVbtX9UeCoBm82PyOZGfzxygduNNt3314Z2aBDAwJF
-+MWqlw8Q9cVsekMSNAG8aFnMrYfLAG59svxejoML+N/9Lb2dRP0eLfHXNqG//dIbgjVRCPtdA5Vl
-J3QdkiuImMDsxha42NzwkmO/RcYjmKPKmRfa+ntwgEuRQJWu7qONfzqR/vYCDhQ30pF2pnzNwsNW
-Zb+gECRncI9HHao9xzqzbD9KdM24QLjYi0obIH9qMwCObHVILTnQlO4GGvg33UhwtC3zHZIPRP9V
-m3kuYyBXwWpEXGk4RUgl8PDB1GijMPmI/rd8O0AbjnaLEb1VrWSS9zDRZmX7JTo2xsaVqGQ/7Cg0
-vlGt0wNrkboflrzZ/jFG+Gz5xrcuUhsKfKL5pQvsK4lMPZYbV1vejj2RTHax9VGlR8K+BfNH2thg
-9ebgKen6mvEX7zXpFkya60d4GgBBOHDpWdDhriFbumTWb40n1YNi7U0WO9iA1xrqLnmbE6s7hRQU
-sTf2pASKIP3wjLsTtaj0ndvlSyYFyboVslRfn+meJEL1Csqry6GeBvzHBrgZOeldzbq5x7XRiSYn
-t6wt5/aQc0sz1MDB5GZOpRk042BerDjYGY8YoezkCQ==
+AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEn64D/0RbxXDknAQFNb/2t2wxTi5bb8MnGm9SyqD
+Uha+SCCoeq5J6qbhu1Ss5GLe+7k0j1US8dLYjMdCEETw/J1x2rgZ3p+Kmmx6G0ZmRHtNDV25lUqn
+MecgwlibsFNZDsaJAbSpNcNrk/xes+avxlFVYJQGoIwonrGJ2qYCsronfn6XwG3vJnfiSPV/izOz
+7mjl4D67GfHqQzkNHrYsWA7eHWkOGVBLV+tSWxjZOZQ5LyhyOG+BiAp4PXSIEoYTsLFmemuaH6ii
+HuxlypnBrdCYupjzR+txP5wm66f2MBzZCUYQM5G2wpXB9skyKzhiHdnNtzx5D4gdXqlCncpyEoZv
+abg4/EZyGS2EsJJkse50NCfI/K0JZ2ADc8BPDFiC3KrjbhKh+wjDXAR9njOECiIXFpQradVMPkLW
+oL4fS+13BBewgVIA5GWd/QUk7hxM9yJVHZ1OMHgoG+v8KkvpUqT63+yd52jjxt+ZEOahkd0ejc/I
+qVbclR5vQcSm87+JSymPXuOK0hHoT2jCi2MHx4YIHIg376FrWKcgzl9chiWQVN4KZaj2bm9T4YIE
++JGFcra0EWjqiEj8aCJFkVHOLvpLkonsMSrqqs8FtDjkZDf8Wbi4Keavt2P83xwmd6yvGXF3LDhC
+nZRfP5zfNgQSB+EoLsEVlQnT2WDbLNyhb4KaYx4wLg==

--- a/ubuntu-core-24-arm64-edge.model
+++ b/ubuntu-core-24-arm64-edge.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-24-arm64-edge
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2023-12-08T12:22:51+00:00
+timestamp: 2024-03-12T08:42:32+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEo6AEACtqPOJs/askgd/90P+XlUhxAQIibwP9rgX
-rg+tdyRtxbIXv4w1SsLfoz6xtIBywe/mmzL5mdw1urayVrtFUBCJRJyOFRNCzEloImcFaBh0TBqF
-LQ4qsPO5picaYgyb9HHCTwTFePNlEWgDohtWlFCNBbuwroDeDKoGfN8YCh2qpxufBKPyZQaPOibI
-CI1KBIWl9Out058SmLCSHw1AERNgVw0DL51nGVt6aKXxShiHYUH27aRYI8sK0RbOuHznUBRR8+BF
-YZRdJ/x+x5OG2uAOCWL4ndDBv/b0NAlJVy38v5oCvmtCmgsjTz2CXyuIAQ8OR+hXUte4aY/4uoTl
-J8veYs41OE+A042g8MCVSID3tkEYrLsS/7W03wUXOoDW5m1NTGGp1V5TjIZrb31J+e8Ya75umHY3
-D4IHOXcQStdfNXW+bCZvtkvXsD5Zgx7aUEyMzy/gLP0vNX/Wqs3s2W+KGLLLXuhaVHWS1zs/3tBc
-3b/EMh7YK8jqp2jDmbsO9iE1NRHIvg54F7ydUkt5r8QlxOj4wwU4llw3sewZ2sCfxjUJ81WQpZNN
-wBYB7NdAkjrQTU4CObE3fhCgU0dTR5drg7l5SopA8es5SHpjtSTv9rNX3W2r9JTKJ65INmEjA6Is
-RfC+R07aWOC2RIsHYPkLMP/RV3ybMC30b138wn9WKA==
+AcLBXAQAAQoABgUCZfBvFgAKCRDgT5vottzAEleoD/4hhtpAkpq8cy38nQps8bnOEPXGnU//2EN8
+/f/q8uxuyG/kRqvh7fBAfz/oKHeLpVxKWny5v8AJ+BxQB6o8kx1OLWhBT0vALwLhlLx9lEFI1UUJ
+BO99AQj95/6eyezymaYqexHWJipTsFFcdV/3cafkUZHqE4OYNdc8RKy93e9XSr8mXW72rxRufBxP
+OkibyOpxib87kqfXYVze14cOLaF2+/XJF5VKhIBpHr1Cz7/q+B6A8m1kE8qNeoHwrpi3z2UVF9dX
+vYDo90+mStEkOYgLrAi12diINO665rO3z/zpwbAMyPTO9GI7Y/iMlbAj0Lj3M05/W51D0u8UZ5fr
+sxEkrMxATZWATHvyY3eFB4Jxe6cRHk7UP87R5YTG8LX+wpWx+bNrJDE7LCxyi4as1x0kIz8whfyw
+P0LvtFRiVS3fCtrxXgpo4dxmUf1RRuvP2EAJLx2T+/dpvppQ13tViagFPxtULSfUSta1KYohLiSN
+rWXdQt4Lf06cBRG+qHov3Ab+jbvNDWkso6yT7wdMkr3rJrtU8J70qRmqEbrsha+3btlPph6KKqTR
+gt8jGNlyJy0K3YkBwaiQC+UO1fxgiSbt2ewgh8AmQpl0/RrUEH/4OAiI7tm83sexoFnxHxDm8A85
+Bvv/6uPZG4fryzuRmceg1vU/yqusn3KSPWG4yqzqEg==

--- a/ubuntu-core-24-arm64-edge.model
+++ b/ubuntu-core-24-arm64-edge.model
@@ -28,7 +28,7 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: 24/edge
     id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
     name: console-conf
     presence: optional
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEn64D/0RbxXDknAQFNb/2t2wxTi5bb8MnGm9SyqD
-Uha+SCCoeq5J6qbhu1Ss5GLe+7k0j1US8dLYjMdCEETw/J1x2rgZ3p+Kmmx6G0ZmRHtNDV25lUqn
-MecgwlibsFNZDsaJAbSpNcNrk/xes+avxlFVYJQGoIwonrGJ2qYCsronfn6XwG3vJnfiSPV/izOz
-7mjl4D67GfHqQzkNHrYsWA7eHWkOGVBLV+tSWxjZOZQ5LyhyOG+BiAp4PXSIEoYTsLFmemuaH6ii
-HuxlypnBrdCYupjzR+txP5wm66f2MBzZCUYQM5G2wpXB9skyKzhiHdnNtzx5D4gdXqlCncpyEoZv
-abg4/EZyGS2EsJJkse50NCfI/K0JZ2ADc8BPDFiC3KrjbhKh+wjDXAR9njOECiIXFpQradVMPkLW
-oL4fS+13BBewgVIA5GWd/QUk7hxM9yJVHZ1OMHgoG+v8KkvpUqT63+yd52jjxt+ZEOahkd0ejc/I
-qVbclR5vQcSm87+JSymPXuOK0hHoT2jCi2MHx4YIHIg376FrWKcgzl9chiWQVN4KZaj2bm9T4YIE
-+JGFcra0EWjqiEj8aCJFkVHOLvpLkonsMSrqqs8FtDjkZDf8Wbi4Keavt2P83xwmd6yvGXF3LDhC
-nZRfP5zfNgQSB+EoLsEVlQnT2WDbLNyhb4KaYx4wLg==
+AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEo6AEACtqPOJs/askgd/90P+XlUhxAQIibwP9rgX
+rg+tdyRtxbIXv4w1SsLfoz6xtIBywe/mmzL5mdw1urayVrtFUBCJRJyOFRNCzEloImcFaBh0TBqF
+LQ4qsPO5picaYgyb9HHCTwTFePNlEWgDohtWlFCNBbuwroDeDKoGfN8YCh2qpxufBKPyZQaPOibI
+CI1KBIWl9Out058SmLCSHw1AERNgVw0DL51nGVt6aKXxShiHYUH27aRYI8sK0RbOuHznUBRR8+BF
+YZRdJ/x+x5OG2uAOCWL4ndDBv/b0NAlJVy38v5oCvmtCmgsjTz2CXyuIAQ8OR+hXUte4aY/4uoTl
+J8veYs41OE+A042g8MCVSID3tkEYrLsS/7W03wUXOoDW5m1NTGGp1V5TjIZrb31J+e8Ya75umHY3
+D4IHOXcQStdfNXW+bCZvtkvXsD5Zgx7aUEyMzy/gLP0vNX/Wqs3s2W+KGLLLXuhaVHWS1zs/3tBc
+3b/EMh7YK8jqp2jDmbsO9iE1NRHIvg54F7ydUkt5r8QlxOj4wwU4llw3sewZ2sCfxjUJ81WQpZNN
+wBYB7NdAkjrQTU4CObE3fhCgU0dTR5drg7l5SopA8es5SHpjtSTv9rNX3W2r9JTKJ65INmEjA6Is
+RfC+R07aWOC2RIsHYPkLMP/RV3ybMC30b138wn9WKA==

--- a/ubuntu-core-24-pi-arm64-dangerous.json
+++ b/ubuntu-core-24-pi-arm64-dangerous.json
@@ -4,8 +4,9 @@
     "authority-id": "canonical",
     "brand-id": "canonical",
     "model": "ubuntu-core-24-pi-arm64-dangerous",
+    "revision": "2",
     "architecture": "arm64",
-    "timestamp": "2023-12-08T12:22:51+00:00",
+    "timestamp": "2024-03-12T08:42:32+00:00",
     "base": "core24",
     "grade": "dangerous",
     "snaps": [

--- a/ubuntu-core-24-pi-arm64-dangerous.json
+++ b/ubuntu-core-24-pi-arm64-dangerous.json
@@ -36,7 +36,7 @@
         {
             "name": "console-conf",
             "type": "app",
-            "default-channel": "latest/edge",
+            "default-channel": "24/edge",
             "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
             "presence": "optional"
         }

--- a/ubuntu-core-24-pi-arm64-dangerous.json
+++ b/ubuntu-core-24-pi-arm64-dangerous.json
@@ -32,6 +32,13 @@
             "type": "snapd",
             "default-channel": "latest/edge",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-24-pi-arm64-dangerous.model
+++ b/ubuntu-core-24-pi-arm64-dangerous.model
@@ -28,7 +28,7 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: 24/edge
     id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
     name: console-conf
     presence: optional
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEuypEACVevClAft+ApAOkBJ+g2ZBmRkyv8L6Gjn3
-9R77w/FYPdgPanGwGcBgF51L2tnJ5kp/IMDtNqdQ1vUofFzEhC4D/+DC1LY4qJhdjeimFAv2PAaB
-px+aiMkr6kx/lwFycsniNZusPG/TLZrMt0IF0bOrMP5gdY4DGMSnmwRXymdg0tzGt9B4I7PkyB3e
-mB/WNi+kkj51wOQ1G5qVPzh5m1X5GafYnx0P+keUCZgBwpIWTE1TOo/vulau/n1j7ktc7SIK1HLr
-ooS92lKsNjSTN5Wwi9A2b1sUbADZBaXJhSLX8Vz7bETCchfVR8PyaV9VGd12uhV2upMeHCF5S14f
-3P9i+jFIdLX/skUCLXedxslc8rRC7y1nGAdvdfQHSDItYdsBvUaAYrHf3+SCuN7QBgAe/sFPGRRS
-WGnITjOmgJOlMZYiTlI+qRLh4KoPtuifMkx056+RxLaml0t7PeBKod0N0TBd+CKNKrwFNqaPKePN
-BSdnPhRLH+s2ZD+QCkqa+KqgCV9zBd46nEg05ANus0o8ZMlnH+hbI/Psuy4mMj9MgALbgMpaxl4e
-5XHj7MKqsokdMgwjgopJNi+Kh3dfDhdlhZCpxGHLQsgG6IQAl5uSWyHTJSp931eQVbA6uQdmbii8
-bpPT75fnoZePTSxDG3Q5XltcZA3vzgAFNiPe8n63Kg==
+AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEhcOD/4wdy2KD8cZU5cJlh7UT0wU02KCHGqLzH6e
+I12DeA/pkCv7GDW7ihjYaliFfGiZDBJDzZKH2CpsDKFegmGyHCgZmHJ5tqiKsLDuzwVUKZwhPbdu
+aKIslawA1HRLvXSJDDg1dbZbObIgOHs8iZvWox4a7U7x+rPN6CTBvVVE5cGXX5kIsOiXdI6RO8JS
+PHRm4r4ZlgvWOK/xsCQk7UT1FWoJIJmXiGNbR7EuYp0fkmDU63ND9ncTyQYQTI3Rjo3EVQs2Dwne
+jEdZirhYWOyl6XWc68JmsJ2SZlDGB/6KPLEKbSUT//6AQHVyLe/T7uRMXd4NL97terYd1WYSqCOT
+Q5IV2/bMspGfySjaxXK3vrB3+HZj7xLjKUJfhNmwFvNiWlQBUQTR8YmPRam523U1ovpNdYZlt0du
+vcVRMruW8lx3hTdgerpqqXvxZm8FHk5LUgEj/h59zvd7ZsmSfSQbTom07ON81wX4mkIPTx+mbelw
+kDgX5BER2tO4oapzq9pPiUT+hGKGW36Pni9S2e8dIM6wvlPRWhGqNuZ0nUBNhg5DAQGE4z31DUBK
+sAgee/Wia+J16FZGvr0Ni9o9eiPyay6GDdi5bvU9fLq/Jus4nWOWKCpv7pM0SMnjybaG6URj0E2i
+TnEpXi4Y7HHPQMUtmfhwr1+hymT2MBI28g3jFGwtTQ==

--- a/ubuntu-core-24-pi-arm64-dangerous.model
+++ b/ubuntu-core-24-pi-arm64-dangerous.model
@@ -27,16 +27,22 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
+  -
+    default-channel: latest/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZW4VNAAKCRDgT5vottzAEvD0EACW2GN54FK8KfdeApGdoLUGbXFmWe72TEKD
-DTyr5H5EZ2YRuYkSwKzrHDi+DpjFFW+61b/LztBpbGgWjGdOrjxSXIUkTKQfLsGpHw9mzopZBfqb
-zyojuNFO3/LB/d5nrx8a89Mz/Wu/ptxqaUicTxm2uzSTFBivKjQKQfz8UjipSEUcQ3Cflvdm80Ub
-F7EF0Sf+zNpcqS6lfgLoWDbVr4J3EcYinjIQHQo7IkKAVaS/PrZ3SvmcEyWS1/6AALdiI5U/PX1B
-RBnGv9wyrMZqSRhP7rD8l8NbdVVJ4lMgLowqSDT00P0ATB2heAxqBLDnVPIiDl/N3daKerdpgcYb
-ZuuAEle3yHRSk92sDJzXIa/8us7Ib+wz2MIwDBwHDCpUo60cZPEejof9tpg9K+gW6z3sYMi1uIRI
-pH/si47VGV0idZg+s5lHoO9FmGVr3M55aBZLWM15Wod8yS+f2XojHMFI3ZLOiJfmmjCjxRgVJJvy
-Lat0Ozpuzp5H7LFa76gQdjsUpUIFDLtdep0vAjSZdz3HsWoesyChjDLfPlYGOP+kXhOsUb/IWZ3p
-woCcm/IVhR3kl/vuJRTMlXyRfc9lP7u7rR3kvBzdzTVLGXKFmplU8gjlArF4C9FKNAyWI+z6NF8f
-TnKxu1s1i5bnwdkQWLDAeV4QvOfk14NIwoULEwIrXA==
+AcLBXAQAAQoABgUCZdeFgQAKCRDgT5vottzAEuypEACVevClAft+ApAOkBJ+g2ZBmRkyv8L6Gjn3
+9R77w/FYPdgPanGwGcBgF51L2tnJ5kp/IMDtNqdQ1vUofFzEhC4D/+DC1LY4qJhdjeimFAv2PAaB
+px+aiMkr6kx/lwFycsniNZusPG/TLZrMt0IF0bOrMP5gdY4DGMSnmwRXymdg0tzGt9B4I7PkyB3e
+mB/WNi+kkj51wOQ1G5qVPzh5m1X5GafYnx0P+keUCZgBwpIWTE1TOo/vulau/n1j7ktc7SIK1HLr
+ooS92lKsNjSTN5Wwi9A2b1sUbADZBaXJhSLX8Vz7bETCchfVR8PyaV9VGd12uhV2upMeHCF5S14f
+3P9i+jFIdLX/skUCLXedxslc8rRC7y1nGAdvdfQHSDItYdsBvUaAYrHf3+SCuN7QBgAe/sFPGRRS
+WGnITjOmgJOlMZYiTlI+qRLh4KoPtuifMkx056+RxLaml0t7PeBKod0N0TBd+CKNKrwFNqaPKePN
+BSdnPhRLH+s2ZD+QCkqa+KqgCV9zBd46nEg05ANus0o8ZMlnH+hbI/Psuy4mMj9MgALbgMpaxl4e
+5XHj7MKqsokdMgwjgopJNi+Kh3dfDhdlhZCpxGHLQsgG6IQAl5uSWyHTJSp931eQVbA6uQdmbii8
+bpPT75fnoZePTSxDG3Q5XltcZA3vzgAFNiPe8n63Kg==

--- a/ubuntu-core-24-pi-arm64-dangerous.model
+++ b/ubuntu-core-24-pi-arm64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-24-pi-arm64-dangerous
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2023-12-08T12:22:51+00:00
+timestamp: 2024-03-12T08:42:32+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZeny/AAKCRDgT5vottzAEhcOD/4wdy2KD8cZU5cJlh7UT0wU02KCHGqLzH6e
-I12DeA/pkCv7GDW7ihjYaliFfGiZDBJDzZKH2CpsDKFegmGyHCgZmHJ5tqiKsLDuzwVUKZwhPbdu
-aKIslawA1HRLvXSJDDg1dbZbObIgOHs8iZvWox4a7U7x+rPN6CTBvVVE5cGXX5kIsOiXdI6RO8JS
-PHRm4r4ZlgvWOK/xsCQk7UT1FWoJIJmXiGNbR7EuYp0fkmDU63ND9ncTyQYQTI3Rjo3EVQs2Dwne
-jEdZirhYWOyl6XWc68JmsJ2SZlDGB/6KPLEKbSUT//6AQHVyLe/T7uRMXd4NL97terYd1WYSqCOT
-Q5IV2/bMspGfySjaxXK3vrB3+HZj7xLjKUJfhNmwFvNiWlQBUQTR8YmPRam523U1ovpNdYZlt0du
-vcVRMruW8lx3hTdgerpqqXvxZm8FHk5LUgEj/h59zvd7ZsmSfSQbTom07ON81wX4mkIPTx+mbelw
-kDgX5BER2tO4oapzq9pPiUT+hGKGW36Pni9S2e8dIM6wvlPRWhGqNuZ0nUBNhg5DAQGE4z31DUBK
-sAgee/Wia+J16FZGvr0Ni9o9eiPyay6GDdi5bvU9fLq/Jus4nWOWKCpv7pM0SMnjybaG6URj0E2i
-TnEpXi4Y7HHPQMUtmfhwr1+hymT2MBI28g3jFGwtTQ==
+AcLBXAQAAQoABgUCZfBvFwAKCRDgT5vottzAElwRD/9kvDyjS0W+w57xCdnZnAKb4lVJfbXfi8oU
+S0WKJH7TrNGsc1vX/ta1iVurMd7/zpEE2QFQjw8TCElItDpoe+1eEFnEpuIeiwn6Lax/eaISAQUv
+9+fjZYlD1DeQ9Yg3ZI2CRaDPCkO1KzL6A7jgaqsmS9/EM3PGrWtkvv5edJ0208vtY6zJkjXq0Gku
+xFwu6r8PTozG8SUqr3U5uDWsP2ROjIifrgEZbiWrlFT+eEIldBxSuWhMs+DlMZjttUABkSMv7DnC
+Q97OzXgzoMgI0YbY69Fw5Arz+Ng5+9naSXMuigyWc8vdklRcefsJTfxINBLak1pK2hjSrb2Sz3PN
+mw5FMtFQzDgLdLyPVmdldSSk0am+aCyKVvCl9Jc1Mvu2r/fQ86d/sxRBx7ePTYD1Uita/rkED8IM
+3aNp3fjEV6U7K+/h5GlcnUnKsIcy3fpCO0W7R+GiXS6EzC/xm/ikW3Oh/EhSZ2H8uVS5N7BulLmo
+DYZHhBvj3Jq0VLmb/ORizrP28zBQ6QqtcGoDymLNxEl3cElWkgyRfkbEc8vI/RLee5+uRfRQ91zZ
+HptZ0UBxNGzTiQOmGPOH3S/CpARFiKDy5IxbccVj94plWD6DITCbjoAUda60x06n0+qJiDXmLGD1
+cyQQV18rRgqEWhmABpZ/KJ06WWSx1xgF09wmLilL/A==

--- a/ubuntu-core-24-pi-arm64-edge.json
+++ b/ubuntu-core-24-pi-arm64-edge.json
@@ -2,10 +2,11 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-24-pi-arm64-edge",
+    "revision": "2",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-12-08T12:22:51+00:00",
+    "timestamp": "2024-03-12T08:42:32+00:00",
     "base": "core24",
     "grade": "signed",
     "snaps": [

--- a/ubuntu-core-24-pi-arm64-edge.json
+++ b/ubuntu-core-24-pi-arm64-edge.json
@@ -36,7 +36,7 @@
         {
             "name": "console-conf",
             "type": "app",
-            "default-channel": "latest/edge",
+            "default-channel": "24/edge",
             "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
             "presence": "optional"
         }

--- a/ubuntu-core-24-pi-arm64-edge.json
+++ b/ubuntu-core-24-pi-arm64-edge.json
@@ -32,6 +32,13 @@
             "type": "snapd",
             "default-channel": "latest/edge",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
         }
     ]
 }

--- a/ubuntu-core-24-pi-arm64-edge.model
+++ b/ubuntu-core-24-pi-arm64-edge.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-24-pi-arm64-edge
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2023-12-08T12:22:51+00:00
+timestamp: 2024-03-12T08:42:32+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZeny/QAKCRDgT5vottzAEjH7D/wM+EDU4BsUEQSYXpJvhl3AHdHJYnpJo2fG
-dV4C0qKWRRVaikNx3LmMubkYydO6q4pjcJnZQ54QguNHixccZViUFd/Z819Rezhj4BGwuz4r9kl9
-CBG2DAwFz4bBqRvYo38RwqB+TjCspQ9H3WfrmYNWiPmAZ6fURA60otjkiNsI8PyypyoRv0VekuBR
-1bSDBWNfJRVjyK8eySAnxUWxyc+aKbac/9B6i56OfkVWQ6V+Pp5tVsGszVsIB3qGn6irVimT/Qvs
-3VnU9Ht7whqJV8y8vvjlOEAOKcOEgt86a5tpzcVixa7UgouJS4hOeLRrN/PxHfEcilCvVX6KcIP2
-WVpQ8HHuCuq/XteXv6qsuXjJQdvyCDxWsqnd9Pu4zCX1tiFRnyY5Eu7BIMTlyXWAmZUomKk+5RDU
-Z5cOhtwgzVdgsWP5X/KzTBAeAcgzPhoUz2I4rIEwa4MwYr5UGUB6EB2iYl0JeIpUZZsiim3/aWQ+
-y7F1dB2AViqJFODKiTI22dAQkzmmcaCgHG0xEigK5gOk6afWgk7ijDoil3Rigrc/T8rLtHsWFQTX
-FmcvJSPydMlhSXTgDWPhGiQc5Sow3xbkvD6w4dL7d+pLkOPzapKwlljr+FdjGjhs6Y2h3fD/Mx22
-xjVzTHpz4Yxb6n0tTjj9AeqJ4K4N8qsv89CWWzDABw==
+AcLBXAQAAQoABgUCZfBvFwAKCRDgT5vottzAEpCiD/wKkwUNYgrWStXeABwFUijAhljvcEfY6XQ7
+uBC3tACXXipqMAORwf5FS5kJCF06X9fjiv6/xPPKv9h7nEvXxVu+cSNL/Kr8Ov8mqylfIROxJOi8
+BCELCnOgeU7/vDniOIwdqWamgnoFoswKrmWJ06zptfsPiRHSOYd/KUiRgyE2tQHAykdP0RriCO+o
+VIzZRHL4eT5IMBCZrtP9d4eS0sVy5vhZHMhSJTAmNVYxVY03XzrBO0RibQMZbq2de1BzoIQcbXhN
+9gnLoJgtysnEL6rDe6xJDncivJADbj44C9x07/IqfN1Yq4iwmiORuliM3VNzdr6okpJCMR+OmrIr
+WdHtgIT8vzfX+opUfFZZGt0W2Q35+/IDr8zq5o+NwHq9gJOhEd5CUf3k7UrXW1yBaYKePzxyMlpY
+nygQdr7uYXJxHAWEpjWBCpFXcccONuQfZ99LTqb8g/e7bFrG2eP0g+1dQZTshHl2XbsiEn2L9MY1
+HpjtaFuv3FiaFmMIkbzyes+DWSJj6geoA04h1qZYUwrM7FrMnZEmXcT/MaHpFQYv3yfaHhZgNeko
+eBt0hYhzpdwbR8SEQolQjE1c85IuGA7GkADMtc48q8bb0H4qOgOGZcRFdEV+UBtE9uhtGLP+DB5c
+xytUJfn5Ir+G2Zek75ELCq8waYTh1yi2mturSnW1Xg==

--- a/ubuntu-core-24-pi-arm64-edge.model
+++ b/ubuntu-core-24-pi-arm64-edge.model
@@ -28,7 +28,7 @@ snaps:
     name: snapd
     type: snapd
   -
-    default-channel: latest/edge
+    default-channel: 24/edge
     id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
     name: console-conf
     presence: optional
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZdeFggAKCRDgT5vottzAElUXD/wLyBU3ZxHBytc5CKMvTQE2TnWgi142Xl1g
-oVPgpDi4h5fCyAEpNtyN09e3Bu7cwMKQXLFk6RTaKBtGH7kzLLNDqwYdSunhZfYgVEEFMIvYxSNQ
-3R47EWhSbkD9WRYEvi50xYrKn+9E59fCbXs+TTKrlq/0Ukd7Ez8xEPQIA8gaOsVnR10gUYXeHBOS
-mEV/xeB/69q4mYK/a5fgZZ0xLcJLYHoE8VuTNleMwnTs/RRw2SXEXrScDOQB0aPaUTCffLpU3dOt
-FcS2ni+OSGgcqrpjfUPaXSe7jrSsQ+5Vry2Ws3RHGuW9M7vISSHdsQhdugLYJI8l1Y1EP84em54o
-ongOMZljCeH+VzI3P9YDGii72AG3iuyc+mccYpseCN75jhaZcmmoBURy3xH/sGs2htVnjmajtgmx
-7gpCcrjGPVXUHL25AfGS9O+ra4PtaeuxN9o8mqTAlDwjdLDd8pW08ulJBDjF+Q0RPmEer2I8pxo/
-9tj8pJUfmEIpgUlzubhTxmxXjxX/zTMuXNh8e+C0d959DJ2su8hJpf5Rd8hmN8VaoRwrYBuzKd5F
-XAa5b0sQQpPiBJMNoid7CxIb4LsZkwrrJllJ3XZPd1bi2nYGgeDM7IW/D+/10+GjWHy0UffKev3E
-jZGt+T1ZfDoz8E8tUZmg+FOu3Nrg4LT9VNlSPpECQw==
+AcLBXAQAAQoABgUCZeny/QAKCRDgT5vottzAEjH7D/wM+EDU4BsUEQSYXpJvhl3AHdHJYnpJo2fG
+dV4C0qKWRRVaikNx3LmMubkYydO6q4pjcJnZQ54QguNHixccZViUFd/Z819Rezhj4BGwuz4r9kl9
+CBG2DAwFz4bBqRvYo38RwqB+TjCspQ9H3WfrmYNWiPmAZ6fURA60otjkiNsI8PyypyoRv0VekuBR
+1bSDBWNfJRVjyK8eySAnxUWxyc+aKbac/9B6i56OfkVWQ6V+Pp5tVsGszVsIB3qGn6irVimT/Qvs
+3VnU9Ht7whqJV8y8vvjlOEAOKcOEgt86a5tpzcVixa7UgouJS4hOeLRrN/PxHfEcilCvVX6KcIP2
+WVpQ8HHuCuq/XteXv6qsuXjJQdvyCDxWsqnd9Pu4zCX1tiFRnyY5Eu7BIMTlyXWAmZUomKk+5RDU
+Z5cOhtwgzVdgsWP5X/KzTBAeAcgzPhoUz2I4rIEwa4MwYr5UGUB6EB2iYl0JeIpUZZsiim3/aWQ+
+y7F1dB2AViqJFODKiTI22dAQkzmmcaCgHG0xEigK5gOk6afWgk7ijDoil3Rigrc/T8rLtHsWFQTX
+FmcvJSPydMlhSXTgDWPhGiQc5Sow3xbkvD6w4dL7d+pLkOPzapKwlljr+FdjGjhs6Y2h3fD/Mx22
+xjVzTHpz4Yxb6n0tTjj9AeqJ4K4N8qsv89CWWzDABw==

--- a/ubuntu-core-24-pi-arm64-edge.model
+++ b/ubuntu-core-24-pi-arm64-edge.model
@@ -27,16 +27,22 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
+  -
+    default-channel: latest/edge
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
 timestamp: 2023-12-08T12:22:51+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZW4VNAAKCRDgT5vottzAEjoyD/9Q8/HsIs1GBGd/L0CUvf6S8JG4N2yiTjFf
-mLFI18n984pixT7g8507zP8xyGUs+eMU8+6glJCBEci6S+y3gDNc1gSN6/o2Vfsw5gLf8qXE1wVb
-UC3oJ3Bfz6Rg36kYgWQx3RzYb9lrJSOco/E0wdcrzC1GPp+1MVY9nkhEz3rt2FYHaKM/X+QYBsXH
-GUDK11JbqGA1G+aEwPcmUQy786A1XnAfVmSkvh7d763MxfTf58d217zkWOzTb6cFqbomAl4mIOzD
-oxuus65fuvHMhtVi5eIuRbe6rC0Cq7tN69q6yaX4N0ydSs/NlHSPb+eIGdIJJyFfEzJzVRiNepXp
-wsUaFbV75CdmpdwYQP9veQqRxVsi1XeKz5d5BONVvIbUNIn9brauyUmxvsyLD/rcIyXCelUx9lw1
-6fOeRng/hEslzQmSEh7VJB0SGECezyzAN+5zJV2NB09WOKpHL38OEZ1xC9h6fXQPG2+1cOiY4D5H
-mpFM0p8W/eG7S8QUCm9mdo022yEzen+HNotbcnL+KI1cKX4x2em3kIQboF4WDiyE2I5azjaXBBqn
-YwHTMKShy0TTRqzkpOx4snKDDxFLUofRzuluBMNGThUK+IgAuoLflLrDbPQISp360pkseRq3bf5t
-GLPYhBq1Y+nH3KOWISqyMj/yWJMnUz2B36gWBB9apg==
+AcLBXAQAAQoABgUCZdeFggAKCRDgT5vottzAElUXD/wLyBU3ZxHBytc5CKMvTQE2TnWgi142Xl1g
+oVPgpDi4h5fCyAEpNtyN09e3Bu7cwMKQXLFk6RTaKBtGH7kzLLNDqwYdSunhZfYgVEEFMIvYxSNQ
+3R47EWhSbkD9WRYEvi50xYrKn+9E59fCbXs+TTKrlq/0Ukd7Ez8xEPQIA8gaOsVnR10gUYXeHBOS
+mEV/xeB/69q4mYK/a5fgZZ0xLcJLYHoE8VuTNleMwnTs/RRw2SXEXrScDOQB0aPaUTCffLpU3dOt
+FcS2ni+OSGgcqrpjfUPaXSe7jrSsQ+5Vry2Ws3RHGuW9M7vISSHdsQhdugLYJI8l1Y1EP84em54o
+ongOMZljCeH+VzI3P9YDGii72AG3iuyc+mccYpseCN75jhaZcmmoBURy3xH/sGs2htVnjmajtgmx
+7gpCcrjGPVXUHL25AfGS9O+ra4PtaeuxN9o8mqTAlDwjdLDd8pW08ulJBDjF+Q0RPmEer2I8pxo/
+9tj8pJUfmEIpgUlzubhTxmxXjxX/zTMuXNh8e+C0d959DJ2su8hJpf5Rd8hmN8VaoRwrYBuzKd5F
+XAa5b0sQQpPiBJMNoid7CxIb4LsZkwrrJllJ3XZPd1bi2nYGgeDM7IW/D+/10+GjWHy0UffKev3E
+jZGt+T1ZfDoz8E8tUZmg+FOu3Nrg4LT9VNlSPpECQw==


### PR DESCRIPTION
We are aiming to drop console-conf from the base snap, and moving it to it's own snap for UC24. This means that for the reference models we want to add console-conf as an optional snap in the models for UC24.

However, since this drop has not happened yet, this PR will be in draft.