### PR TITLE
Update UC20/22 dangerous models to use beta kernel

### DIFF
--- a/ubuntu-core-20-amd64-dangerous.json
+++ b/ubuntu-core-20-amd64-dangerous.json
@@ -3,10 +3,10 @@
     "series": "16",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "revision": "1",
+    "revision": "2",
     "model": "ubuntu-core-20-amd64-dangerous",
     "architecture": "amd64",
-    "timestamp": "2020-04-29T11:18:00.0Z",
+    "timestamp": "2024-08-01T11:18:00.0Z",
     "base": "core20",
     "grade": "dangerous",
     "snaps": [
@@ -19,7 +19,7 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "20/edge",
+            "default-channel": "20/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {

--- a/ubuntu-core-20-amd64-dangerous.model
+++ b/ubuntu-core-20-amd64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 1
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-20-amd64-dangerous
@@ -14,7 +14,7 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 20/edge
+    default-channel: 20/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
@@ -28,16 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2020-04-29T11:18:00.0Z
+timestamp: 2024-08-01T11:18:00.0Z
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCXqmLygAKCRDgT5vottzAEjtpD/976igsvImmT56zho47BLbkJYPuC/lgvI+8
-84Z9Oi3Oq7oRapm9Fn8AnpKu+0K98XWv4okdjgRrp0fo2ClXcWfQLjMKAtT9dm003hVEjB1IEk1n
-SJ2kwmIDvnmFLNA//tteZ5DsAIOUNS6Ug9jEsyMNCgKCKGe2Lprxeukn2VcqrVym1d0chGPsz/VT
-Jtwm9WGkUrBqLWj8vfzOaEToqLBDxC7AU5SnrsQpNwgsrnnjFJfY8CBYbcktCC1T7x4Vo+5qEqmA
-B99nQPBBHLgT4lA4pQwW/n4h1qJPQvt5SMwtYjPfFpaVSM+Qvs8j4ZBOli0xeP4oIDNJ2qRZ6nkb
-hdr2abPWh7wQlmLW04qfJRN7iMBX8vCMWRBlJzFADzfdYHtKs00MSbQoUEtF6mB3Aq84TUdZ40RG
-g4ylkYgG5XGAQch3vYwS4LTlqXosXWoPhiMHvrYWlJQBeqyUXD+onK/J1QNM9ff5twH15jy11v9F
-ODVTufUV42f70aA6y43cv4Kt8uc0GmHEmMhwYq3NBiOZuLEjKI2IFLJcZchYsZck3/NLMbVi2KrN
-aMzgJqkgefM4WbuOpVR+PhfMx5vTnL7b4IFMH6z4tsXKkIRxX+wUgrSIhjE1Dpl4jnHuQM2pF2oq
-pbrXk+N/WD0PgoPFDXilYqpqj3kw0B/jVUiWhUZXBA==
+AcLBXAQAAQoABgUCZq/3cQAKCRDgT5vottzAEuODEACSsiz+IpWRLkqMhNNPs4V6omm5H3uvY0pR
+w5pEobNru3wDUzPYZ6oX/GSb0lmhBmXV6g4t8g5KmOtEVMY4yQWVx+miF8ZtZJ5jDZY1qsm8QytY
+ZMR4J1rRcNElgqJUdY+G0aFF2htMemU1sj3cRxLzbncWP8aohnASDA2mnD7c5jy/GtckchY+VbXP
+7Kk8k7dCXm6w8mhu5dNRZCAcxHYF7ItUhW3H6YdkwjrKaoSnJP3P8M7l8UCLN1db+HkG69lGebHF
+ZvMYxV5xMtqpEuowZrI5SX0f4qGyGX0yRROzuGiTopJPKyYlygMrXiDQofF8uXvlKc9OkYeL0NwJ
+kkRIoZy29/Xa3uZh5OFHLP9qudthtKp/Xz/04VLoywqUxWSPJhZrPQusVgCJAXc2mvGblp1nu3vc
+O4AhzWTJ87acNOmaF7k4/AHKX6XXfwBmPk7LPxqTy4IPdq34gKwlTdyVRRboWiQRmPoIL8n2bBEY
+X8DW/N0hnTCU9w9AilXh0Tw5nzU3JJqtz98aGUeiigznY8tbLq65d0Oj4dX1tQ+jY8HjjEpGGvMk
+g0VdvtSZH5onun/p+D6hXloeZpr9CWc24CEDP+7sPus7IV9ADAsI+nCYDrpC2XlPlqv0vuggvD5a
+ut1T6TsWU9tlAtwDO8W518FfF2hSCfaA3Wed/QgptQ==

--- a/ubuntu-core-20-intel-iot-dangerous.json
+++ b/ubuntu-core-20-intel-iot-dangerous.json
@@ -5,8 +5,8 @@
     "brand-id": "canonical",
     "model": "ubuntu-core-20-intel-iot-dangerous",
     "architecture": "amd64",
-    "timestamp": "2022-07-04T12:31:19+00:00",
-    "revision": "2",
+    "timestamp": "2024-08-01T11:18:00.0Z",
+    "revision": "3",
     "base": "core20",
     "grade": "dangerous",
     "storage-safety": "prefer-unencrypted",
@@ -20,7 +20,7 @@
         {
             "name": "intel-iotg-kernel",
             "type": "kernel",
-            "default-channel": "20/edge",
+            "default-channel": "20/beta",
             "id": "v7evc8smSqgPwL0KCjpGJf3KuucG2Yap"
         },
         {

--- a/ubuntu-core-20-intel-iot-dangerous.model
+++ b/ubuntu-core-20-intel-iot-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 2
+revision: 3
 series: 16
 brand-id: canonical
 model: ubuntu-core-20-intel-iot-dangerous
@@ -14,7 +14,7 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 20/edge
+    default-channel: 20/beta
     id: v7evc8smSqgPwL0KCjpGJf3KuucG2Yap
     name: intel-iotg-kernel
     type: kernel
@@ -29,16 +29,16 @@ snaps:
     name: snapd
     type: snapd
 storage-safety: prefer-unencrypted
-timestamp: 2022-07-04T12:31:19+00:00
+timestamp: 2024-08-01T11:18:00.0Z
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCYsRwWgAKCRDgT5vottzAEpTbD/0QSuXYDhzA0kQ0s9xP9zuVCavKqAv1T1IJ
-74AelIp52tgmbnRewjgP3i6kRizFkwpI7XxYNgS5lfpSkL4JaW0SYxrSok9Rz4dzn078cJji2l2y
-Py4qh7odDK39WDxUk2JpFBtNYoGqnuLaX7ND2LXtZ7TMzYEg6eKhY4cttLQfNJVJh8JthsnzeyED
-a4WDrgh3WS7k2zme5qfMr6eEN84dUtj6iJ3d+sUbTWjmR8cLySrpjwBOzc2bWwxrynnwId8CnaXy
-naC1+fFW62OrNDOUUVtwVZKW6M/p6eWzKTCvzNMwzQ5M4uqbTFGj/LsAXQl7/ZnIZieH3Q0l8WuY
-zqek1LD3WAj0jIhRhNrjP9X0B3hSh7QMiYRifPRVgm6H5z+80kvLzkDWLkd4TO8OV8hWj1dHI1fY
-n7j6HZFEGFOQNH+JGfHcTERlwW7JoEfN3NkHeZioCt5Hb431G6KAkL+1quparQ8Lexa8aAAfbBet
-2aoDyx++r1f4OpEt4oyZDfRu6TdEKs8PJZxiYrkM6H9QTLFrnjdPjNfxU4CVyOYupCS+u3wWF+EY
-S5z6oonekLA58NmDtlNpdxVZ+THFlum95+3WtZTHfhF8WYvXYa4iMezauLPRr37MnP189meZB+Gj
-UzQ3iAE21RXNYKLFHAOscwVBlhfpmKWbbkmDvMnOrQ==
+AcLBXAQAAQoABgUCZq/3cgAKCRDgT5vottzAEn+fD/45mr3bhEpwJDL+8jKEvH6ytKpJXi6Gkw3I
+/no4aBuF4OJu/ouR47PGt4+QSa4HZ5VXzHsKCe4OcHTIfKzwuUWrSFCF7tQ6wcRLiZYmFyiAQ/JG
+gl6nZvCkqycO6VPT8RsmeUFWpBUtqH/Oh/vaQyhd7xjG83upNKMJNuxVv22Dx8SrvjjctCOT3X0e
+QSFOqLpbR0mPSP28pUWMKXrcypykO+x7OCqOzvaQRwco+Gq2mzZs5ZZPTxgxyHmRLaLBYwNfcgub
+mz6HC6ggYZgGiGk1A6ViqhZTphUb1PuYfDEzIkJqH6TvOs8bdyv+tbWigg/wPxfD60kInBrP4ROG
+fe4HFfy3psqyuSK/buPv0h5jXXVcgBi7KCRZ3EpZUy7ZY8S8rmIuTla5RRjJ1JTAM8DYSBZIbUli
+QmapkunNhzzW/LGQxsxBL9Hbtv4xjDHf4WTzRTN5yfPFUdI7dM2er8LEls10nBQ+LaEPbuMRDsoM
+QU+Jv7w0uPArZYEHs/pHpYIm1SF3Uic0jYHc+mK1t+zd3LjlJIfVJrLwmMzONWdgJNdwIjq2itvb
+/zI6lD7AFs7Nrxbsl7o+2f26uBW1wfslZRoJyATatPu1rFBo1Qky15dcaHpBeUEPriB0iRaomuaR
+fwTEkW4h8+AzV7BkEs7hvya6mEsRo7sLYZZPaLnMPg==

--- a/ubuntu-core-22-amd64-dangerous.json
+++ b/ubuntu-core-22-amd64-dangerous.json
@@ -4,8 +4,9 @@
     "authority-id": "canonical",
     "brand-id": "canonical",
     "model": "ubuntu-core-22-amd64-dangerous",
+    "revision": "2",
     "architecture": "amd64",
-    "timestamp": "2020-10-06T11:18:00.0Z",
+    "timestamp": "2024-08-01T11:18:00.0Z",
     "base": "core22",
     "grade": "dangerous",
     "snaps": [
@@ -18,7 +19,7 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "22/edge",
+            "default-channel": "22/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {

--- a/ubuntu-core-22-amd64-dangerous.model
+++ b/ubuntu-core-22-amd64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-amd64-dangerous
@@ -13,7 +14,7 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 22/edge
+    default-channel: 22/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
@@ -27,16 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2020-10-06T11:18:00.0Z
+timestamp: 2024-08-01T11:18:00.0Z
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCX6ArRQAKCRDgT5vottzAEgMcD/sEHSh9hRbJ1dbrk6+Ey5imVRPUuP0QV5fp
-HyNGmqwOJ10mEHMUqMTGvriwSO+JpOWtoUxX+sHLVeVDr40qey2cmjtz0pHcaqfO/VD4GXUU53ef
-sudVwmqY4SoW60Q0xHItNVB2wlxOCXHNfm9HBTpG3orXGhHqZEHTnC6BnDCoD+kDyrNd9iHFtcej
-lw0qtYd4O9qhxWI6w59h7egcljB2Gc1SFvCyVE13JUMghMLpZeqK0EtrKuXashLLXwF4Kkb85OqJ
-mv1rS1BwyjV2n++zjE8BXzUz6vSbQwEydXPj8cPZNF/1SG01HROu90nrjIeSn6xBipNVeDcuwErm
-6tHhC+TYxiTG3YPZGwqO1xIYfTJfGLZ2EFpb0oW7DZ0JxNtuDg7Cqaa1Kr4YUulcSbOpgCUmHTVI
-/1z/grnoDVU++WFuNOWXSQdiKBy1DyLAfXYWCI8UvNiqEQi7+GyVKiyUSivyFzCXXj2hdKVt5rCo
-YIu/9nXlHtJLtEFWyXEtYtNCbrMs2YgR8BxNEGaisFE3HLFS/2EVtG+s9deYEEo62B0qaZj+nJ35
-BxJyUe2el12B1VIEWy3npJ7KGwvbFz0iTh4W0+jio9QSJ7KyXZTLKGx4en37ZCYuPnjI6Il1KUjH
-VRhqFX10Uts0unZphiNZxuSGNIUf7Gn0Vl5z+3iKsg==
+AcLBXAQAAQoABgUCZq/3cgAKCRDgT5vottzAEv/JD/9UtJW98ugihzkonKylHaapsiBCZj9A/d06
+ZrHL90AUaBXmjwMUtL53S8aXxHFlq9TPNv+Qvj2I6r9pPuJzMyDMpG5F6wjAjsnbLq43u2r69f+C
+nJNF9DuDxQ8SokSchpVuWCLXwKH4P3xvNfhdNiDEkddVPRlt1+ViUofH6NP/9Fz1wRm2h34x9JT8
+h58vXvHDszQSqWn1L4SEOsFindtQRH4kR0NJyIfz6T3cEH1Y3BLLIQ3+ypLmj2LUmGkv8XDS2WFI
+MJ5lOrnC+07cg1slRy+j2igGlAsJHPdhzmCMS2UD9rXq8v07ON0THExk/isUswJkrcWRVluzrGyp
+ZuACkJg713eHUL2p7Yku7d5N4AkPbit9OkOZhyqpFtnKsyiI1VK57iQNy13lTTJnDdYRfCGNXN04
+uQc8KlISecqYpnk+3iPwdOq5gTrY7UKFFAfMmkkxOARjB33pzGN1scdhTNJVvHJ/ewp/XV8dsGHc
+2L/iGJGmoANgOS0fRx6S/3w+P16qjYqn0hoDSrKf46zOfrriV9RL7bxROh/IlW+tB+kpy7vzjmyY
+MtcWaTI/Oz17s6pOqbLhxp7FLaVxwHCCLbXagb7odXMn85vsqcYLLN5zOu/4/RQnnj+wdKDLpXXE
+sxbA1nsHQafmCAR767ogiRr9wLDmhF1iKg50F+sZKg==

--- a/ubuntu-core-22-arm64-dangerous.json
+++ b/ubuntu-core-22-arm64-dangerous.json
@@ -2,11 +2,11 @@
     "type": "model",
     "series": "16",
     "model": "ubuntu-core-22-arm64-dangerous",
-    "revision": "2",
+    "revision": "3",
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2023-03-02T02:03:23+00:00",
+    "timestamp": "2024-08-01T11:18:00.0Z",
     "base": "core22",
     "grade": "dangerous",
     "snaps": [
@@ -19,7 +19,7 @@
         {
             "name": "pc-kernel",
             "type": "kernel",
-            "default-channel": "22/edge",
+            "default-channel": "22/beta",
             "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
         },
         {

--- a/ubuntu-core-22-arm64-dangerous.model
+++ b/ubuntu-core-22-arm64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 2
+revision: 3
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-arm64-dangerous
@@ -14,7 +14,7 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 22/edge
+    default-channel: 22/beta
     id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
     name: pc-kernel
     type: kernel
@@ -28,16 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2023-03-02T02:03:23+00:00
+timestamp: 2024-08-01T11:18:00.0Z
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCZKo7sAAKCRDgT5vottzAEr4dEACwWDcDrqUrusEVeT28Vgh87amYfDA6DafM
-hHh46UlEFVKZzPoI9BmljLGr71NYTPbbw/4F8aIlX662lYDHgqBG5ikwJhhi7CZ1Zp9xH8f0+rny
-DywVTaWN2EDmNKxYt4a/aRy4JP0Sp1F3yunWiQC1mp5p3UTF0dYxeOJnPAlDc22nSwNDBAyeO6ZK
-9ex2PFGUQe0avbMlWavuLR+hGGCyqNKKf4jq8mvCPzZ4mLkkACXudVyekHIChjL5WWNyJBAjUM5s
-iLghjIBU/a5ykPCOSfpG4GpxrOe2zb9ViYR9b1KSNAxvlQd+MDasdqG77Pn2vtVxaDFbeyBVAy5F
-PVHuHbpnH2yPLlqJ1M5RAd/ILYdD2vVsRAE2rX8LQA+GM7+vF7NDjg8K2fR48fteTq5ektzoug8C
-zgJhbPzHQ36JfFBEs7397KFvT8dQIy9HLoiZbwy8iGohv/e18xdC//rWL/17CUWCH8rMsBQ5qp8s
-bvBaCPVo0+a13GaPaoTfmavXg43BraReKOefl85YM7hpbl2SVVKKe8Z/0slQ3m8o1bn7syFrmzcL
-JrTIR7lbmGiwg7hN2IHWwfghMg4nhLfLDKJjMwYJF6tG1f1uLUXVVUTCNacbWrgS4F9YHFgzPtAA
-UyWhwAjQ5+REWVyze61czP1pH4ha0NobsdfiQR2EVA==
+AcLBXAQAAQoABgUCZq/3cgAKCRDgT5vottzAEh5tEACTdKcrroT8T2SyeM2xZrrQDQDFnEWZD6BK
+GZGbqmP1rBC1xJQXRIAkE+oVaNPFX97rEZ6ge5IKujdLFTFjX/sA+lFrCUbdv3QdWneQkzS0mqIb
+F7MiuXZlC10UH58ngP6G23a/qL+sTfYmehpqfMq7Z3Wiv0F2CTx6UUv6KmvbXteWUn66GuTccFGf
+izcHhkCgMliFZ/EvUalhDUALGA8vJVPP/bSIBKQ3BbUtq8DS+OjzRemsRuuPMczYUdiRp4wwxiCz
+mnsKiM8RVyp52K6jPnVV6R19ozlL7bTNbW7VeJHKgUcr3ifLJJ6DTcvdKUrwfQyMFCP7MUhMbtkG
+CPx53L65HDRBuEedpaasQGH0fRXRCiTdX7RUubCZcjWYw4oBZSLpHGnOUM7Mhfj/B7d492ZqAG6X
+2Oro7nsSSy9/J7sHA82Vgh8RTiZtQcK6iWwkuhboPsXUpLQ4qqin3ySwGI58XGjqnN9H4MsTB+Lm
+uoooXSWGS6Cs5fx7M11GNKhw3QKV5s5gYtxKOOPiGTtFv0LDLcARn5zjHPeepgbxVyizNEmtEo4v
+NdVosHp9Do69Fpsz52vsFBoA4sxGYFI5yna015pexw0XjVwM6WP8cSg9Naep0Y6ctMYkbx9l4BeP
+JY54y9cdZYiRwo96smsmbsbRGi9sBkqYdy0B/utaKQ==

--- a/ubuntu-core-22-intel-iot-dangerous.json
+++ b/ubuntu-core-22-intel-iot-dangerous.json
@@ -4,8 +4,9 @@
     "authority-id": "canonical",
     "brand-id": "canonical",
     "model": "ubuntu-core-22-intel-iot-dangerous",
+    "revision": "2",
     "architecture": "amd64",
-    "timestamp": "2022-08-09T11:15:46+00:00",
+    "timestamp": "2024-08-01T11:18:00.0Z",
     "base": "core22",
     "grade": "dangerous",
     "snaps": [
@@ -18,7 +19,7 @@
         {
             "name": "intel-iotg-kernel",
             "type": "kernel",
-            "default-channel": "22/edge",
+            "default-channel": "22/beta",
             "id": "v7evc8smSqgPwL0KCjpGJf3KuucG2Yap"
         },
         {

--- a/ubuntu-core-22-intel-iot-dangerous.model
+++ b/ubuntu-core-22-intel-iot-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-22-intel-iot-dangerous
@@ -13,7 +14,7 @@ snaps:
     name: pc
     type: gadget
   -
-    default-channel: 22/edge
+    default-channel: 22/beta
     id: v7evc8smSqgPwL0KCjpGJf3KuucG2Yap
     name: intel-iotg-kernel
     type: kernel
@@ -27,16 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-timestamp: 2022-08-09T11:15:46+00:00
+timestamp: 2024-08-01T11:18:00.0Z
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCYvKhLAAKCRDgT5vottzAEocZD/0eUkVIln/KyVZ4a7AaLU7L7G4IWQiItTVC
-OyUA30MhuuiZhnP2qM0yLPMTWfBhLixdPVJlo8zb0lTBoZJU/6CwLb7G+T/BSCRrjJfXdW2zhc9p
-7JaVzedWbCaxIzkM89asH5NfK8K4IpQfl9+aFJ+2zNYK8PC7+hNc6dv28s+xTrabOISm6pakaRuk
-JNI/nE0DG8rCSvgwSII15noVlVq+/nnE/JfiBI7PcDMcHULAhuWwetEeQ2N/+fkZzaAX6C6PXDz5
-25gknrvU/HGe2gMBo+SWGFZQYDHOa787cMs/k3yyFOKKIAGn278iHCR6eNGo95XFqZDrTt+o6RkD
-T1Lgm0OPvMR7eL5SS4UBWRpSp9wJbycBRXdIk9JyMrIDr+HNK7qtzkHjNDvPOhLs9S9HrSEF2DQm
-obioDTBJ+7oY9Kn1HfCqG5HeeQZ3y2D35eM8j2zen7h/V1jfmU2xDW7mr1+78uZ8lWYIjoMp7Rlo
-RCXowNPv6I2mCgnXMlo+/00oRMsF3P7BgJ6uz2Gdwf8aXhBsOF/U4NJ3XukLQCHJu36BPcoi8nld
-0ToEC2LGnCCXTZB5SxRc/0sx6jz1Bjyh6XDSp/h5ksBw+YEyTGe7LqZDrJ1nMpeYXOqUd8tNtTv4
-1yF7ieUXCsrHUEFHJDoYquaRnWBp3y4a5MBx9pfSYg==
+AcLBXAQAAQoABgUCZq/3cgAKCRDgT5vottzAEqf9D/9EcMPKALFMIkX4BS/DqyCbcFV7mQX8Syij
+LwWlgx2T7UPIJ0xtTjBk+EUfcgn0xcZezKrkDaydrm6y4CMx3dh9FgEA9mO9OBwvNpSM+2UYS5yF
+MN+5OrisPIb09W3RwN39dUnQcEGwlWVBoptmsEXtya4WylbLqMTFYbdkHhWADIcpnHSVKdjVyaYQ
+Hu8nwwtYDHAvBUvKGZbfgIZbaTTjY/jfllyNdy+xXr62lxQHGjAqnWGct8y9OHF+3xai1fEMwY1R
+HePV2HJR+dlDpG4wh7ZkrDLforqLjZUus1Xjw6y08rvhFcfMeqaByD/F/0WdHmxsDgJkMfsjhZUs
+nDc1/BFU9JBa4NriXWlsImQVM2GlHCuMujwZ4CM8kjhKvZvhU4iMCmw5+JLQmTnQetQ0tEAj7eFR
+WERdm6fEmxROHDRpBdJP0knKil4OnCFMg/wNup63Hhv1J2NycjGiHwGCORqhhnB+NU7VdrrKfDBU
+JlGuSC/hxLN+1rNIX4VX7fIbtK+0A8wNcfmRY9cSRpmtL3/N3NyjIXuPQLtaVWCw5wwDx1j6eYs+
+QCpiJnOObugJRYIxBu66Kmqi6dQLXN34o7OvSNGriqOIgC68VfkHfPccN3R6q3ygDzHXniV4G85m
+M2Luf/RGqD5F0ewlcFflxqc/ojuNfJXrdI4BuHtI8g==


### PR DESCRIPTION
The edge kernel is not signed by Canonical keys anymore, so we need the kernel from {20,22}/beta to have images that can do TPM backed FDE.