### PR TITLE
feat: replace pc-kernel with azure-kernel

### DIFF
--- a/cloud/azure/azure-core-24-amd64-dangerous.json
+++ b/cloud/azure/azure-core-24-amd64-dangerous.json
@@ -8,6 +8,7 @@
     "timestamp": "2025-07-29T20:53:33+00:00",
     "base": "core24",
     "grade": "dangerous",
+    "revision": "1",
     "snaps": [
         {
             "name": "azure-gadget",
@@ -16,10 +17,10 @@
             "id": "ix2UbhTKGMg7FOL29vAcxQn0qktk7eSa"
         },
         {
-            "name": "pc-kernel",
+            "name": "azure-kernel",
             "type": "kernel",
             "default-channel": "24/edge",
-            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+            "id": "QdLm7X3eivGPViprLsTqy0JqVDRz6Wzy"
         },
         {
             "name": "core24",

--- a/cloud/azure/azure-core-24-amd64-dangerous.model
+++ b/cloud/azure/azure-core-24-amd64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 1
 series: 16
 brand-id: canonical
 model: azure-core-24-amd64
@@ -14,8 +15,8 @@ snaps:
     type: gadget
   -
     default-channel: 24/edge
-    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
-    name: pc-kernel
+    id: QdLm7X3eivGPViprLsTqy0JqVDRz6Wzy
+    name: azure-kernel
     type: kernel
   -
     default-channel: latest/edge
@@ -35,13 +36,13 @@ snaps:
 timestamp: 2025-07-29T20:53:33+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaIlHKwAKCRDgT5vottzAEjHnEAC3GhSa4LB60kC2TXTB/NvoVpebKYT0PH5a
-UZ6BFQFm76zGWO1tccGC6b5CTMs8e2a7zun+ogqFEMfqOemmtpWaD+DclqQVeB8RQU8A3++MnnGw
-1U/96/7/iWCwCFtebJTyFGRAeqp2Y9QtNErAX3Qmei3+khYTUnIj3CWG6o7UGidWFesCcpGpjiiG
-ocK3CoFNip9wbaUNOQ9BOFE6lo5BAE0HtsCi4fI5lP2cC9bIuRTH+RD0SodPNIMTPB58LbgG0Mr+
-v+vz3nfjemtyn6zKeIFx/EKxshnqyUy5Gz9lS2IVNuXPSgkPytcv0ErxGtTVUL4NHnbWFVOPkJRl
-XesZ5GMzN7X7HB/bIZAsju53MiknwHCW9BpWimMFoeXEyiqjdcnLWDK33ilf1GJP4KNwx1OdDJIo
-IZygbsYJ1XT8e0Dap3yfSHD41i9tLJD8ujsov6hr6XxhDMnVtCSSF9q0rtl9wY53a+dFCrqRDOj4
-lRnFniKi1C8FYzE8iXY41Gw4OxS9YkP3ClWGsTWxAH13z/X/R69qMWxuAif+WHJBECo09irUTzA0
-EUPl9o3kA1tXNLzexYgmK6w5qyiRVB4B90fLh2LFvO9fRRN/x24bm0URTSaDMAqSEJ86z6+akABh
-K7u8JyLOSiv2y0tY2MkWLRsWHQK+CZwSBq8mHY1D3Q==
+AcLBXAQAAQoABgUCaPa0SAAKCRDgT5vottzAEpIFD/4zHs53PAC2MKZNj8GjmD1hcnFhgj4pKaZB
+EjrXJ3ZrKOqZxJ1Trk863khbotDPZ1V2WljB0Tx/Uy6kXzrYV55XHRy6KBArHoyhEJmbY7hJtH3t
+EjQwTb/b9szqD6aI5xU/ftyZSehBuRPwY2Kwx2NxfbjcfXRDAPLCXxpjf/6oKk+XGDcsYNuU9xu0
+znroAhrjORoXRVMCKcg3qPrBGavDNUxiYYykPaBWyCcXoz9cplbeL+gpv4aRNBjKUjSfEeYsfyvz
+XKvY5DRVv6VOtxHINqzn8XcV5J/sTHR8k0meB2U+HCCY++fJ6ukD4BwflA2PIJxCQDS2LbWc/LJn
+GuOjb5byTbWrn1znoMNV7YoUOGECWkszvg/EXR9vjin8LmtwA/PgADUcmHvcA7s1zTqLxKr729GX
+SRDa7yrLQWvj5SYFbSvurhW7ROAhl0Nqs5EzRipARppf08OdBnU4BW1gQo3jGZ2A56BJFDxpDznI
+nQ70VPRe48lUqMW8ccbreDLhUUmvS2aYrdnC5+gtAXlF1i7tBeGqm/c88eT8CnVIOVlWRr9LLcS3
+zZlwVWtBeEx64z6vvbtDXiE1l9P6gVuIci8bTXRqbk86Aovj+aFQ0I+MklPh6K13UUFiMzkWe+qw
+aAu0xueruonEDnEtXh1bl4Q8gVzai/ct76W9f7W9/Q==

--- a/cloud/azure/azure-core-24-amd64.json
+++ b/cloud/azure/azure-core-24-amd64.json
@@ -8,6 +8,7 @@
     "timestamp": "2025-07-29T20:53:33+00:00",
     "base": "core24",
     "grade": "signed",
+    "revision": "1",
     "snaps": [
         {
             "name": "azure-gadget",
@@ -16,10 +17,10 @@
             "id": "ix2UbhTKGMg7FOL29vAcxQn0qktk7eSa"
         },
         {
-            "name": "pc-kernel",
+            "name": "azure-kernel",
             "type": "kernel",
             "default-channel": "24/stable",
-            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+            "id": "QdLm7X3eivGPViprLsTqy0JqVDRz6Wzy"
         },
         {
             "name": "core24",

--- a/cloud/azure/azure-core-24-amd64.model
+++ b/cloud/azure/azure-core-24-amd64.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 1
 series: 16
 brand-id: canonical
 model: azure-core-24-amd64
@@ -14,8 +15,8 @@ snaps:
     type: gadget
   -
     default-channel: 24/stable
-    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
-    name: pc-kernel
+    id: QdLm7X3eivGPViprLsTqy0JqVDRz6Wzy
+    name: azure-kernel
     type: kernel
   -
     default-channel: latest/stable
@@ -35,13 +36,13 @@ snaps:
 timestamp: 2025-07-29T20:53:33+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaIlHLAAKCRDgT5vottzAEmKKD/0RCdhx5eszWukkS340LejHcbpBbKNdmeu1
-nlseP1/dm7JFaen+Vg8jBbcGVw2L8qf1R6u+ju2mxMhGVrqZVdyge191KkYH2kfrtXvvrO27UOhD
-8ks562Gf1yhtdDGqvDasTJdWuAFgcdkFBFua1SUFuquV4pNnzx6ctM3XFMIHAyNCAVerCNjTxCJw
-gsKwwrkh09IYswMFj3eV95CHvzf21kaeG9kMLKCbQXLEDluPYNJEV2lm62aML8Zn1xwmoV4fMcYK
-i6BcIz8r1IV6Pd+/JeAnsH+u9VJPJyok1Q44vmL04fWMMK/IicZ+1KEXlQZWDTGE10q9Kgg/7foZ
-RkrzSK1HN3zlrh3lRBxgRSvDRDbBWbqq8Hg8AQnGumtuZiyaQHQWC43+lLfSBgcNgHeueYxz6SQQ
-G9liOku7DANdKzjZ3Vcktf1H1kkZpjZN+77ktXc7OZjt/2hdZPgO1ceFvceh7ui/bH3mJpA4ye8j
-RIyQW/vok1HcM3CgG0SfqycZvLQMct2Kone1k6xY7EEEhZlB8P1/phSdfVMAfYW1Ndi0lS+Lekgq
-vQ4vUK3H6OEFH/r+wCFxDUsnGY10HtFdRnV0kbVQOirOoR19TJ0VTNnwfveor4jTx0zLxkvtFIZg
-L4Nkx8WPTeZjjW1eBjD6/Y9JdNQDQ9vu0IiFOFrsSw==
+AcLBXAQAAQoABgUCaPa0SAAKCRDgT5vottzAEvrsD/4ufAyv+gLBuq9h3vNTITnTXts1+EU77+Yf
+CFCPGbgyKbWDkXh6XjnTReeGgh1SfIMrJuSQZvh4qFTNRjQHkjaEe9XyyrO+Btlb/CA075K2dzdu
+DEoQwoUBa+6O0ngNnbY7ZcGC0amng8p6IlSOTXzIvZ+aF7WkopHCC3+DUzXGpf5E98WGP/waymHn
+CvzwLlvQP1QXaldzZZYG/n8FwmZsTHKukOvn0J3eHZAY08Jwg2frF53hnmPnxtJY31oJ3w/SZefw
+DvRnh3LCyy4ZVj57lThCOH9UbMqhETdg6erIq+f90iQooxzDSQo5TJreUe3f8NzweALgOtuUvAq0
+HcZuF7b0y7s1/QjBniSo0FoQ/kL9txtHHgMTR9RCRgvvif7ru52E0l9N9w2/x9f9+CXkjQ1c39Oi
+EHiX7FOPS3FJ9E/zOe9cqaLQVE1i7LBSxQTfp2DfvwA1cq9Zu/rP5c70Qfhg74570VmOGdgeVL7Q
+dMDZFEpO805Y5bBBBvdJyZVEUyeO37pI7bl/v6ngg/jrmaTvAEPhrFeiuVWQ0dek5oCHkLTPfK0K
+JYB96OokuEBGH1YhljSo76DtXf2P69VlIRkFv+p3gRQbV7ea5H8esiuwxlivzKd2u/9KGgvgZenf
+fWxtvXm54pDW20RsyBf/SCX/TqLe81DjQeT4R4vWaw==


### PR DESCRIPTION
The Azure kernel snap is now available on all requisite channels and can replace the placeholder pc-kernel snap.