### PR TITLE
feat(aws): remove ec2-instance-connect from aws models

### DIFF
--- a/cloud/aws/aws-core-24-amd64-dangerous.json
+++ b/cloud/aws/aws-core-24-amd64-dangerous.json
@@ -8,7 +8,7 @@
     "timestamp": "2025-05-19T07:49:42+00:00",
     "base": "core24",
     "grade": "dangerous",
-    "revision": "4",
+    "revision": "5",
     "snaps": [
         {
             "name": "aws-gadget",
@@ -33,12 +33,6 @@
             "type": "snapd",
             "default-channel": "latest/beta",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
-        },
-        {
-            "name": "ec2-instance-connect",
-            "type": "app",
-            "default-channel": "latest/beta",
-            "id": "dkikqXSj0Gt92zalwAwU6OaoCMnaYc5W"
         }
     ]
 }

--- a/cloud/aws/aws-core-24-amd64-dangerous.model
+++ b/cloud/aws/aws-core-24-amd64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 4
+revision: 5
 series: 16
 brand-id: canonical
 model: aws-core-24-amd64-dangerous
@@ -28,21 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-  -
-    default-channel: latest/beta
-    id: dkikqXSj0Gt92zalwAwU6OaoCMnaYc5W
-    name: ec2-instance-connect
-    type: app
 timestamp: 2025-05-19T07:49:42+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaWknrAAKCRDgT5vottzAEtZIEACZzy5MaGWFQxk5sdEWKwf0UmueBx7fPxeB
-a9SVjIjnm69jCQj18vciOO8cn4+vSGp78uKgQktx4RL5sxISRJYALV80Wu717M2dafht9fH8+RA3
-bsYBZANQj5c6zVVYGvOoqZ5FPwg1czHLGd0lqvX7mtzcSTYYoK7IKIkkLHPfMUF92jYTlipYGbAE
-OJDyjdeMiRLK+Eb7gfSxFkwARZM4q9y4riN3mMvAAc3ErQGH4hE9umG5NMu3wLJ4fZQrwqMIJ5B+
-QGpE1JXpp0BaQ6RV/hfjz9qGbBGgKgXJmetCdAg+CUNjVi5c4chKoLxlK6NNGSG5GdX2OpJFcJpM
-Mo6BdNNlr9Zx1QqC/WkIAH0KCpPbEHXlDqobKceNUzh/Hwfqfoi7q+tbGZ9lNO4OcY4B2HT3LLsa
-kDZH1mxsFEjN/KhH1l7GFqM32HtgeiGFPYtfMMLCLy4/YYGuffpInDziKEp57AxgtBvmbQCqaPIJ
-OZjspEwF00pPoL5+z6+hUUzcyJK+sM1DvyyE5+7271rxuYeueW4CDcRI2YuUd6s/3ZGAyHXhQX7E
-hZfYgg2AacxP5Jh65g3iHZjmKmFZLg2QXJ6OmzZ8Dy+9LXwY6ucoZwo6Th1EflrhVhFcL6TI4G91
-gHWqh1jcpcpH8AD+SrtcNVUSK1Xxn7c8/R3Xj53e1g==
+AcLBXAQAAQoABgUCab158QAKCRDgT5vottzAEvIWD/wPFaRlYDg/1qfILZ57vJ8bsAOjkHm5m0kn
+UsbpNzpcHWFA/p51yXGTvp+VvVD2x+dVVteIyTFuNHqaKF+A/9mQ7XSBEgP31sX1iFL4ZyDKAXlX
+rMFBNbm7vJXbzo/gPZXSSjCzqkKxp1lhV1xYmdlX9SrUuTbcpveu//XKoJI07eIzmicXNXttbh9O
+zLTwRbyDRC9eWrkv4/+6oOFZCRIF2LaCfgY+dIivTqU+OQ9lvWfQJz9GgFV9pcKLrT9bLL6fnkP+
+oR3v8ezkyQTV6bZzBhlDm78UYRQs3LJDt2N73tOeoFevm4gtm/ofC2otVt7BJwnlLPrCpLeIswB8
+YBGzvyBXx+Sm/nuH7W+wZ//27n8H27YtIn3Ihp7LBORhzc/Sfx6ykRXh1q+lPtQp7MC/7mPalo3c
+AE9x37oxqt663dleXC4V+uxdzUeUAvTPeI0OFli8lLTYcL9uZcv/O3S4DNaB1LaFcp9Pb7LFvcq4
+J+p9f5kbcuF4P+z1d6gBM6p3ypw278WyXoYtdYo188zkycqKtgmOmzaolFzCfsJpR/wqVNx80QHa
+GDVTtdWh62d8w68fb6GQN3qqpabOhY1Ff8HxMkDm44NZiTJ2wv0vfPhqkMfQaSQoWeFiSYa0WrlL
+Bm0SvKGjGcBSTEWKu/sAcdMQP01OO7dwe+qPszOecA==

--- a/cloud/aws/aws-core-24-amd64.json
+++ b/cloud/aws/aws-core-24-amd64.json
@@ -8,7 +8,7 @@
     "timestamp": "2025-05-19T07:49:42+00:00",
     "base": "core24",
     "grade": "signed",
-    "revision": "3",
+    "revision": "4",
     "snaps": [
         {
             "name": "aws-gadget",
@@ -33,12 +33,6 @@
             "type": "snapd",
             "default-channel": "latest/stable",
             "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
-        },
-        {
-            "name": "ec2-instance-connect",
-            "type": "app",
-            "default-channel": "latest/stable",
-            "id": "dkikqXSj0Gt92zalwAwU6OaoCMnaYc5W"
         }
     ]
 }

--- a/cloud/aws/aws-core-24-amd64.model
+++ b/cloud/aws/aws-core-24-amd64.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 3
+revision: 4
 series: 16
 brand-id: canonical
 model: aws-core-24-amd64
@@ -28,21 +28,16 @@ snaps:
     id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
     name: snapd
     type: snapd
-  -
-    default-channel: latest/stable
-    id: dkikqXSj0Gt92zalwAwU6OaoCMnaYc5W
-    name: ec2-instance-connect
-    type: app
 timestamp: 2025-05-19T07:49:42+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaN9kGwAKCRDgT5vottzAEu7+D/4uBUeI4q/lkFCcj+PlvyocCvQpQadDw8yY
-DcfuL5nkN0PXKlK3KLVRyGZG4Ahr+GB+PqqHuu/NxPUkeX0jrzWh5+lrsyRsWopSAlX7NqVnW4uT
-TFHrYr5w2SJaHvAorP83q0SKSyeq77yvuxyU1hmrKNWLc9Dlm7ibzKa+NROia1pznJpiNKsy/iUX
-kDBIq07B7eT1dONfqAhvpmLGzaQEfiNid5/WhepGsowTNgbkTAudlYovJjV5FDCkYg1dNrORSdQh
-8YA5561A5EIB7JjOWxRdKFFqbuWJhTg8KmZbpPc1UNrt1CWvDlsDBlePMK18kzznvDvVi6arG51/
-Nd20uS187qT/rgY0R2vYDfXTSqGJtw+dITevgxPXgyyN3qgZuazOF/0DLN2ldQ9pPHQntCQLPfuy
-GoB+hTIKI3kP7OwvslR1YUsPPSZaJRm/1JgzTc1ChPWdVyYCZvL+0i8uA7tYZnVrBykIW703/hxK
-ejzaHGAJwrVwjyPK+FuMLdp7kmHmxJ5HoJXo2rCeXofnlIgS14+2yT+79aL1seCFdeeMzqNtiKKg
-nknmIYS04/EP3AkLOK9ppVTXTwqL1x0oqvzoLSU8IxyU0zhvsKD3uB6r3rYavV4ANrFNOKQMH9wa
-MPfroxrWLp1aLH1wa+QeEVLlb+phuSHVUIWYr9q69g==
+AcLBXAQAAQoABgUCab158QAKCRDgT5vottzAEo36D/9bAYrR1b4uYyi37qwswAnOyu8Dy1wIAbg1
+sUH9TLFdlpWyHfWf7P67X1qEQfrZePhIz4u1MvlLARtOebPqB66ja8o2wYejNP4dG5ukx933u44f
+LlIgiKCOpKF+HHWH2jPIjTT9lsoeIwfuMIxyGfTHm5chMWrskNQQV+616vUry1F9kCrDJDY+vgoS
+GVD2wOI20GCjj7llr6dvtBFJxUll0yI9h7JlxYUzEb7g9XMkdWLYTjzRN5KJco73rswym97GE3B7
+qusRDU3Q41ruY0REa4IlXSbRqDdEgUjkbPv7C73bZ4P5FZWSTeeXRp08RKwgU0dqqnudIAVjoPs0
+u499Infmo9ObgaHhik/f6vKAe9rkucfTWSR10z7j3FdqL6E1/cxw25P195nARxcPsETot1uJAb/n
+9mAtnSIS5+/xHlmBBa8pIAvrEcUT3lbR5Zq7ztunpTKFs3dHXU8LLkQ+7VAPzyppc4ytBldTd2nj
+fIgib4FDEJ6iMhNLjfTEkCTN7hJQE6FJr9WGIi9k0SeOcqW1wSLT6Oe+15+C03RFW3NGP9hbnGLj
+TJJJ8OUcrk/kvOetwiBVXHhhPN/brTbmc0YCmOZ/Eau0aiAvPCXWYmhgAjvmWDGu1ObPsUp+SCdO
+0SYA9cLJB/xV7XdOy3kxgNN4v3Ir0Ki9+ONKIOo+vQ==


### PR DESCRIPTION
ec2-instnace-connect (eic) is not needed to connect from the aws cli. Given that this is the expected workflow for a user, and the eic agent has limitations while snapped, we should remove it.