### PR TITLE
Add Ubuntu Core 26 models

### DIFF
--- a/ubuntu-core-26-amd64-dangerous.json
+++ b/ubuntu-core-26-amd64-dangerous.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "model": "ubuntu-core-26-amd64-dangerous",
+    "architecture": "amd64",
+    "timestamp": "2026-04-07T08:00:00+00:00",
+    "base": "core26",
+    "grade": "dangerous",
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "26/stable",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "26/stable",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/ubuntu-core-26-amd64-dangerous.model
+++ b/ubuntu-core-26-amd64-dangerous.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-26-amd64-dangerous
+architecture: amd64
+base: core26
+grade: dangerous
+snaps:
+  -
+    default-channel: 26/stable
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 26/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
+    name: core26
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 26/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-04-07T08:00:00+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEqMLEACX1/lav0Gu8zAOSOnGPz8kGI/ykL5oCwmK
+w/Q5dqOJEcwaO4l/mWGGOq2YTnbJWLMfNoLeDwC8ScNrqieMN4Bu38DEwU3y2yBsZdohX6yujhtL
+TtuTa247YqNdiVIvnxH1imanooxRcYgBqgxnAEN6G/AlN3uqhubl5G++3PXjFuAaSMGUCYYeztfP
+Qq6RgT6EwoyOq5qvGAvyN6BLIUC6yCH3GiKwZkcRMUZC8JEJ3ZxJZuokGuirBW1NwMPBDMWhryBX
+Um6zIxy877mz7f2y23nrUjhp6GXzgBgvQjWqpRjOGYA69USNKa/vUbrvAMw5glDNKIxX2VXjQpzZ
+Qv6dYT2GqXtXvTjDCkZS3weA/OvYtByp44oLESQOfnqc2F61qW0qmK7dWglfPToZ46yxK3WknZMK
+IdhA69Lo1FsXHt7/12YsdshWkYZJPKu7TztwX6ac1jXQvBw7vWB0FSpoyRESWrc5OZYn7xpNQwio
+8N+TLNTHGK1meEBgSQmU8C7Cypqj2/E4AaZ7DywoUxEypyGlqsTF3YDonvvsvgeECkNypK+aLUW3
+GR6rg5drPGw6ggTcdUl6mnirzkuqERbJgQfR3ca9BP4fw5B1MuGWJm7PZdzSqPA/yytJdkSxONCz
+F8bwUbVfJ1mDNulSTPQd5JyIsy9bwClCx2DJhh/Eaw==

--- a/ubuntu-core-26-amd64.json
+++ b/ubuntu-core-26-amd64.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-26-amd64",
+    "architecture": "amd64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-04-07T08:00:00+00:00",
+    "base": "core26",
+    "grade": "signed",
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "26/stable",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "26/stable",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/ubuntu-core-26-amd64.model
+++ b/ubuntu-core-26-amd64.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-26-amd64
+architecture: amd64
+base: core26
+grade: signed
+snaps:
+  -
+    default-channel: 26/stable
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 26/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
+    name: core26
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 26/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-04-07T08:00:00+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEk5ZD/47wHlWk+ZxqTh0NatV7pukIaca/fsTuvB8
+wBlaqBrMswFK6yh+jSsxpLrTtMyOrQ96GlhRw64B9X0k3PxEpKAFFChpYvzEWSTaUnPj5tEqemhb
+9SNs4SxfQEA219frohoi7i1FtzbZxSj7Su9EKPJHbi0n8tVUBFM2Wl26i27HTs86xhtkmLCe6OMN
+8aCjNL98JJNF/ER34tBWRhsL1QDS8QMqDLnojkwSU7NIkpLX12TNDTNVXHVrANA8Zv4WqIc4m1cj
+qkHyjB90DhiVvZwj63kgrhwhpMsh3wHLSVyhuV+lG9s88iJ3pIPaM966w5C9BRTf9cvXqD/j2XN2
+0wsVa0eXPR4tRQMy+DF3I0g+f9sqiAOzr9GKR3Jt109F+UcPr2UoRpvu5jcQWqwGsAfsINbJTWLf
+WZfhAI5J2ED7nc50dq2iz0DkOr/+0MiDmEZR1xpchSQdrWHkbLkmPYoJkJQFnjkqz47rilRzkWGV
+APVmoV1frpWIizDxoNGyd64lzbyHdgV10sy46Bj/4EfX5TMiv/wv//fN/I8QPL1M0G87JV4DsZ5S
+/P8Igy6Ob7jiR8GINVuH2Xby/mmWdRV4OuRRMoTNjvVPIiXI6aBEPs8pSduuWM4pW6J3sn7zzoDq
+xQnaa2Qg8ugcpH9ZqufMQEttrALLFJdez0Kb+spLtg==

--- a/ubuntu-core-26-arm64-dangerous.json
+++ b/ubuntu-core-26-arm64-dangerous.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-26-arm64-dangerous",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-04-07T08:00:00+00:00",
+    "base": "core26",
+    "grade": "dangerous",
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "26/stable",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "26/stable",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/ubuntu-core-26-arm64-dangerous.model
+++ b/ubuntu-core-26-arm64-dangerous.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-26-arm64-dangerous
+architecture: arm64
+base: core26
+grade: dangerous
+snaps:
+  -
+    default-channel: 26/stable
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 26/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
+    name: core26
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 26/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-04-07T08:00:00+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEgbmEACQJzaDT5gLnTfmUZg+xIaAPUvVaV/5QFYj
+QvSfeo+xo7WdnJOQ+bM9iMzuEcyUonpqhtXAN/Rt1MRxMoVihhkANS4bULtmP5irguYolHy/pBwP
+rbyMg/rGf783/WmyozvVI+aw/UTdgseuJ/ypoiSRF7Ad3et15T00peTbNFFcu8lW+I1UYavR/G03
+M0MC7fIi9Ha7gRnBaByHd4RWbHtIj3bJT3eqYaUzWR2wKuZREqJqFjONXeg6thYk3Gx67JU8HTYm
+KCxRI6/zjJWMAbyAkGOsZA0JGgrq9VXmprtiqMMAMB1SD27MBMXnRtLjQ1IQ2pgo1ZrHnip0A35D
+LYUwl6pJc67AAGlKgVZa+o5VRqeaQfEChNoExcaPsjIyrT3ZocgWB3GjOkUdvBGvdkMigcnU/Am2
+WIuh0sZgrf3asCas0LBkrTGOfhNsP8eGntTI73eXC6HDc4JNU9/4LttvWe4i3fcb118cASEI6cqF
++vcQCp0oUxKEKl6T1NrASlJCWAAEvOWDu27kjxJqZWK3lr4pUB6+JIBlKTu4vwwb7/Jj3zVDd5QE
+AkbpLgG5N8SGP9jvvQWdrxRhK9vRFSmwgqZYafIQ/0c6uQ91OaoX6DB1yM2zrCFBP83Ctuf0EvW8
+ZIjPZPlZUSRVZliXif8kaYh0mW2L7qedR3LWgd4hcw==

--- a/ubuntu-core-26-arm64.json
+++ b/ubuntu-core-26-arm64.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-26-arm64",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-04-07T08:00:00+00:00",
+    "base": "core26",
+    "grade": "signed",
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "26/stable",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "26/stable",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/ubuntu-core-26-arm64.model
+++ b/ubuntu-core-26-arm64.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-26-arm64
+architecture: arm64
+base: core26
+grade: signed
+snaps:
+  -
+    default-channel: 26/stable
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    default-channel: 26/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
+    name: core26
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 26/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-04-07T08:00:00+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEnpmEAC3dAfVALESawaMCW7wMZPVvTr04fWUQUVo
+fZTWiCmOcrDjjT2CGoXEb+Tji+pSGW6UXoCSHnPA2PEYN/DFsqR1+CKCbvO2Q5fQCxcVCLCpLarg
+DJSaPwc+XB5V36rMS4fZyVXmsfQ3zkB3TUXZGLMsygCP89xO5GqFG1mnJwX+UxFSSbFIq7jHsWXF
+oHhHV/MxtO9ZJWMAfP51PH2pVE6hDkL4PO9iTQJGqooYaFrXzOk7permDM5dkwtFEdm1NaHWrKuo
+bUJaoMez20OTtKmz9Yv09Um4y9sX3T43Qk8VEm0eIjIH7SgNrHoE3Emu57ggV81dcQk2iJr8KS98
+r5A6L5V13Bpqy7yxvTDuFW8o6+TBXr7u0+91bY/Sv+S8jXYYnqjTkegEdzFu/C8yhm0wY2DSVHmN
+Gv1vr6/ETpc0uzK+wTNdJjQ2RmmTli58stxDRS4KFRRpQrvBZ0ckDjJxgseCjIaCuCwH/aXs64mJ
+4RllVQMuhIorJ1ywDh1FtUfszYZWtrw75uPONliaNQThTtWAPYsUDAhgL7+GA0jjCgKeRulT6C15
+z6tkZFeS329jFyIgn8s2Sbu7gj2ZV8DxJrmXMep0HDodAdDcor3fvoG/yOgRrdiIC6IDdm2luoIH
+0rl/AwoT8sQLk2zqPrh5NYXG5ACST5Gj4G+5IfcDCw==

--- a/ubuntu-core-26-pi-arm64-dangerous.json
+++ b/ubuntu-core-26-pi-arm64-dangerous.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "model": "ubuntu-core-26-pi-arm64-dangerous",
+    "architecture": "arm64",
+    "timestamp": "2026-04-07T08:00:00+00:00",
+    "base": "core26",
+    "grade": "dangerous",
+    "snaps": [
+        {
+            "name": "pi",
+            "type": "gadget",
+            "default-channel": "26/stable",
+            "id": "YbGa9O3dAXl88YLI6Y1bGG74pwBxZyKg"
+        },
+        {
+            "name": "pi-kernel",
+            "type": "kernel",
+            "default-channel": "26/stable",
+            "id": "jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/ubuntu-core-26-pi-arm64-dangerous.model
+++ b/ubuntu-core-26-pi-arm64-dangerous.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-26-pi-arm64-dangerous
+architecture: arm64
+base: core26
+grade: dangerous
+snaps:
+  -
+    default-channel: 26/stable
+    id: YbGa9O3dAXl88YLI6Y1bGG74pwBxZyKg
+    name: pi
+    type: gadget
+  -
+    default-channel: 26/stable
+    id: jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ
+    name: pi-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
+    name: core26
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 26/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-04-07T08:00:00+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEqJfD/4l0I0RWFOj0FQsRBa+GXLXHkq6UvPh6gMF
+l2mETqhqDQN+zX6UjQW3n4IAeEHP13mdenzwzwHVwS8hkFCSeBLjYriUENfY979+fPJp7ARG9VTt
+H6xSJSvGtQpXbnlGonskF0LWWQ8y6Xiev5LVEcMm/SOBwJJ8U+N9wv+Ih2/w/CBqX0UwpgZQ0siB
+JIVau8iSOShNauiF4RljsPNo9+xmwsWFpeHK/SHiyKL20UvO5XEB9IyRqv6/dt7ug1EEaf+rJSDA
+eOED8giIqCpQirYur7nKR3ebr22LE3vR3ll/xuk7w+90iN9ZdXqFAPd0eoEg6SrkZSV38HoDCMpE
+P+4RTooWSCvN93xpYB46GAncx+w6mUDmVuukhsmXU0jNatmCqzDMg7RyZtF9SX5KLmZX3r6pn/Or
+WBxgnVk4Cp32qeV1tIjfX0QiSLcRGFXFHq1t0D1DDzWIkUR/opSze7ThNLLQBJpeblWBMMQYPvCq
+zwsmMdDoJArIK9jl8eCp8eNVlKur/5jCI+jUOQo8lPe4Nm+DAJSS8TD+V8AX1OrUgDjNZ9j+NuZ6
+mZR+U3BMziOx59b+l+FBXLuV415px6wHFnD1VBjqa3t2WSJP1ZGlqrP4DaTq7IMKSCKz8ukDimBY
+6XiiFzpS1eJbPMr895QfYpQZmifUxGd01tO5D6ps0g==

--- a/ubuntu-core-26-pi-arm64.json
+++ b/ubuntu-core-26-pi-arm64.json
@@ -1,0 +1,44 @@
+{
+    "type": "model",
+    "series": "16",
+    "model": "ubuntu-core-26-pi-arm64",
+    "architecture": "arm64",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "timestamp": "2026-04-07T08:00:00+00:00",
+    "base": "core26",
+    "grade": "signed",
+    "snaps": [
+        {
+            "name": "pi",
+            "type": "gadget",
+            "default-channel": "26/stable",
+            "id": "YbGa9O3dAXl88YLI6Y1bGG74pwBxZyKg"
+        },
+        {
+            "name": "pi-kernel",
+            "type": "kernel",
+            "default-channel": "26/stable",
+            "id": "jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "console-conf",
+            "type": "app",
+            "default-channel": "26/stable",
+            "id": "ASctKBEHzVt3f1pbZLoekCvcigRjtuqw",
+            "presence": "optional"
+        }
+    ]
+}

--- a/ubuntu-core-26-pi-arm64.model
+++ b/ubuntu-core-26-pi-arm64.model
@@ -1,0 +1,48 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-core-26-pi-arm64
+architecture: arm64
+base: core26
+grade: signed
+snaps:
+  -
+    default-channel: 26/stable
+    id: YbGa9O3dAXl88YLI6Y1bGG74pwBxZyKg
+    name: pi
+    type: gadget
+  -
+    default-channel: 26/stable
+    id: jeIuP6tfFrvAdic8DMWqHmoaoukAPNbJ
+    name: pi-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
+    name: core26
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: 26/stable
+    id: ASctKBEHzVt3f1pbZLoekCvcigRjtuqw
+    name: console-conf
+    presence: optional
+    type: app
+timestamp: 2026-04-07T08:00:00+00:00
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCadmKOgAKCRDgT5vottzAEuF0EACglXkQ1L8lUkhk5TP8JXDNBmJHaHrCYK/9
+4F8JpY9Um1w0shlu51Ik0Vm9vNflevZRRSS1kDxGxt1/YpP/zHFq3lVm+CQb/KOWSwc829JLQFcY
+my9asSGp49XZmMQaa7VZ1HWInoenlXca2W+GAxXTJtmVv8qizXRxKfOM2UZU0ozm82oZEDjVLmyz
+oAeJYD9y01V/dHHZosb+8gMg9W/EZRWMxQaJBkAU7ZeMR+tbjOShU2hw4fVp+u/L0hbhmWOXbKox
+ibIS1UgYSf+4OhkFQNG8a/x58cyMHxEGPyichfm0+Xwv51CTAU3ksFauB+8eHjrTfv/6xXESKuP+
+eyKXROl4H8MHAzRCj9FaomC+AKv7M9NpMQnq+TKV4mJzljk7yAF+E1nFV2YvbC6FgDbzDnfRSsbo
+cqRUG7mIQLmNPRss6eALzeCGCrSzRToXDA8iX0b/EPU/zBB2xgHG5AYnPGz4655hK9wYDWPsuQ0z
+Eg7HfyGftVzAf8s9pZijwP1VVX35isggFAsnTjxR+Qt6PhfqfNbVqsfaUtAaAP/MKNhV879I1f60
+HfRNURPI6DhFlOhaHzRLRVgnrqArTPUcXsvVYr9Sx2P59NHe+K2mWIoFJylPNf323SnO0wV7c1bU
+2JPj3RkgUsgcUE4ZrVetefzeVhTFVbs1GSQhZAcoYg==


### PR DESCRIPTION
Add the UC26 models. Differently to previous releases, we will have only two models from platform, one with dangerous and another with signed grade. In all cases, the snaps will follow the stable channels for the different included snaps. The channels can be overriden when using ubuntu-image for dangerous models, while for signed models we do not actually want to create model assertions signed by Canonical that do not track the stable channels.

If having a signed model with snaps tracking non-stable channels is needed for testing purposes, a non-Canonical account can be used to sign the model assertion.

The supported platforms are UEFI amd64 and arm64, and RaspPi devices.