### PR TITLE
feat: Move all the cloud core26 models to use the cloud-init channel

### DIFF
--- a/cloud/aws/aws-core-26-amd64-dangerous.json
+++ b/cloud/aws/aws-core-26-amd64-dangerous.json
@@ -8,7 +8,7 @@
     "timestamp": "2026-01-23T21:53:17+00:00",
     "base": "core26",
     "grade": "dangerous",
-    "revision": "1",
+    "revision": "2",
     "snaps": [
         {
             "name": "aws-gadget",
@@ -25,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/beta",
+            "default-channel": "cloud-init/beta",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/cloud/aws/aws-core-26-amd64-dangerous.model
+++ b/cloud/aws/aws-core-26-amd64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 1
+revision: 2
 series: 16
 brand-id: canonical
 model: aws-core-26-amd64-dangerous
@@ -19,7 +19,7 @@ snaps:
     name: aws-kernel
     type: kernel
   -
-    default-channel: latest/beta
+    default-channel: cloud-init/beta
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -31,13 +31,13 @@ snaps:
 timestamp: 2026-01-23T21:53:17+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCab192AAKCRDgT5vottzAEqIHD/wOPOjD0vCzRqB8Thj1N5H1r32yD53eu+P7
-gMTKEe3O5lA7m6zOznLBNgEyKbqIJF7dKCOfXfSAvTuHv9Yrip170GhO/aprPWxstP+0+ns0+Frh
-n51DOZp+KOTEmC30/b4wfMyEMsdgc02TTtzXRlb6ojqNVhN6mTwDKD4I3h8j/i4+5PnZjDmPkr7D
-xE2ABD9TDhQhgG7rfav5muZS8NFPu8cGCIC6VpcTwE051mFyUxUvVt90RvoawYA1jFct510yDd3p
-ordkQtbWAr5Kzf80DXhDBBjrgKdXpRYVFCPycePNbpmgB7mjcOiu0gEpRyWgkR66eEV+Fg0TPrUy
-K46EBAjJsFdT1fENxhhxkbBt5pd7bixmpaIKRCZ2hEQl/WSYr3WWIMCZPzPcR2R6jNbRkWmK0ihq
-xd6vcer0hVd2jr6LUnYn9s+egdpDxDcu8tI2aij+As5AdXjXrm5G59mExsV911Iy4ZJqVmi2+4lN
-O35ml/bR/nstS7uxUzsJF3ZPcYlmbcbvfZDNkVoYpp7RqoAwOgZKrhhu3nwf0uBnn0WAsgkaXAjG
-4S+a5L42jTkloE5mZF7i71v64MDpqhXR6CBOLaP3dorbeBxXz6kc124nPvC38EotVISQMElC1NxH
-nZ76oBs5XFzbLT3wBxog5z3iddZNtkTIgJpjXNDRWw==
+AcLBXAQAAQoABgUCadavAgAKCRDgT5vottzAEhgXD/4+4ODTwDxNS4cvLIpviwTRIbDT1xjgUIp6
+nVfeTNyg7WVnT+FO3/B63dVj5CDIlzqLwcpOPIQZXvyAa1pD3jyKMpqd1LuoK5mFWksl1qJg1Z6/
+UtoWnCX7SHYCDD/HcuCtl8+nvBTg9EjLtXBkAsdq3kguHRlj+L5463hDvKeivU0mA+uVt4nyD+mM
+EL87ad9DCU1ClK0E1VN65gifykFniZ08UiCX+cRN1x64WGX6cgXY4Bi9yZNRQR/tOObqTPQcndaV
+s0xUezZAZTA91a+djcnYY2VGT++pMC/nWvkz4D2VlFqsym1hjt7zTs8EsFTiCqHRhgT95gjSHPhc
+YTUtJf6RapmlF0wrnuLLu5vwAyOtIJcQpYHTMAKsjW+PBBkXPpfx+tAy5xpO9caHGIUY2vGdOceO
+fXv5K/GA9/RtpEZmX8ezGO3L+UMp/krdqfP5fcJS/UluHMZbhwy85DLVxVhdGqVbR0Qh5+i3yM2m
+DFjUoAjGZR6JzDXUNo54B0zftrRwwrliN9Xhtet8y7YgPjU9nwSGmRtzJJTT0xIw92kcjQUwg39h
+s38gm5OIL5rgZX8+j1Bx4haYCVkWqPbDax3ZCurddCjLBvedOqfi/h6DlsLCtphsjkEx8zGS/RzH
+BXToH7Cv+Lk05lygbnUmNqcuWX3+VCA6BeNHnVGSfg==

--- a/cloud/aws/aws-core-26-amd64.json
+++ b/cloud/aws/aws-core-26-amd64.json
@@ -8,7 +8,7 @@
     "timestamp": "2026-01-23T21:53:17+00:00",
     "base": "core26",
     "grade": "signed",
-    "revision": "1",
+    "revision": "2",
     "snaps": [
         {
             "name": "aws-gadget",
@@ -25,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "cloud-init/stable",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/cloud/aws/aws-core-26-amd64.model
+++ b/cloud/aws/aws-core-26-amd64.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 1
+revision: 2
 series: 16
 brand-id: canonical
 model: aws-core-26-amd64
@@ -19,7 +19,7 @@ snaps:
     name: aws-kernel
     type: kernel
   -
-    default-channel: latest/stable
+    default-channel: cloud-init/stable
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -31,13 +31,13 @@ snaps:
 timestamp: 2026-01-23T21:53:17+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCab192QAKCRDgT5vottzAEiftEAC5jLWTGbMiFkMk2OyyQxnZGdMH0VIhd+2n
-xZC9pzzzQe/f4CztCRsrZhYO6UtaBvyLpoFmW6ZWiIdUMF4SXSW5VwhIooWjdDdIh9MdTBnl6FPs
-b7/na+hPLPlgY5un+MDmu155eTY0JCB2OOYVvO4vt8SrQTT76SyY4/UDDXcQt7UI+oFCI4NSUutC
-nr1ddbzp4W8IbFjZoT4sFb8t7L3H2F8ruHVTiu7IjHKmWCqkOV40mh+ZLDr9UjX1D0UR6HP5p91N
-mb2w0h1uiuTah2ex8yuYUp02hjISNvR0RS46ZGoroAF4XN5vphSOxdjKRZ7wcKa8nZAxSsglXX9m
-ZnmpkFpO2l0vIyo2iB9voIGggP1GlIjKF+isr3FKPvempjuavGe8lB6CZ94mnsEAVUWqKzTkKxhf
-8jAm6kOcp7fkP8H6FqsKhuJTsGEoFoLIceeECt4yvDDhbBw5WE2vGrq2Yw12nZXX3XaMCDlR1Enk
-EkvRVAFNLZ5m1xd/MMzePJ79wq4wl0hBrT6OuwOrBfVI6Wzrng7zLobZeTfHAjX52Aafe5uvDW+o
-6eUc5PuUMEyY7LqnI/Dqmh3/6wrAfJJ76re0PPKWszsuah70K63vxnG4Suj1PgykSxIGG9w8W6CC
-4L2s7I7EfTGsGyCYqdLXFR8tAEN/fZO0QnvrroTdlg==
+AcLBXAQAAQoABgUCadavAwAKCRDgT5vottzAEtYxD/9tsuvGrnkAMEJm3pP9TQbhka6e8jx02eno
+TiyHRtaBbpEtifvDHmiQSgB/Xx6cGGbtZvOqCh7/XUzlDwzKKTA39fkklW8CPLm2zjuRXSVBvyz5
+hbLddwN0CdAxzOPFZpMKVqJHxxlf7W+ZszjOjhDCr8HLSL0FfEzew4/3vfdhZVbnYKP3Dyu6S2AN
+hWwfJwIkYoxMSzfbPmA8rC307F69A/wptV7lXn+fHkARg4wUrkeU9sjKdMrlKk5klK9X71qQoEzp
+F34wzL0MKwEIzcPbv6oATml0UafANHVYdphqJspBRiNOJSGW0R54pXYpT3kf/UDwR90QTRkGzkQD
+L7OpQTyDnZXNrNPP33m8L2hBEQjF+YdHGfMUGpzNanrPvgMx+BqpD035gv6ZyxRvFb3VhFR13dB9
+/GcN80D1byFasvUEhhGFLJOFjNB88ZetJI2/dB3El8i5Kh1pBtRwhbIuXJvCSU+o9UI9dOh/Ptqw
+D4rDuLbmXS6oGO8LGz1pqkP/iMnrg/ElNLD4vWM9Bzp0pwhTcJMoUZtg+rPwO/OVIdlmxGblo5PU
+wpl2Fp5EgXbNj6ypvCbaX23kj/yh7Vicgqd2MzHaHtZo+zOY77A0m+KHBEq9ZelQ/kscC9753bmI
+GP4kYISB35yBA0xNHs65ByD8WLAfjSvnYfIEgkQ2xQ==

--- a/cloud/azure/azure-core-26-amd64-dangerous.json
+++ b/cloud/azure/azure-core-26-amd64-dangerous.json
@@ -8,7 +8,7 @@
     "timestamp": "2026-02-10T16:08:48+00:00",
     "base": "core26",
     "grade": "dangerous",
-    "revision": "1",
+    "revision": "2",
     "snaps": [
         {
             "name": "azure-gadget",
@@ -25,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/beta",
+            "default-channel": "cloud-init/beta",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/cloud/azure/azure-core-26-amd64-dangerous.model
+++ b/cloud/azure/azure-core-26-amd64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 1
+revision: 2
 series: 16
 brand-id: canonical
 model: azure-core-26-amd64-dangerous
@@ -19,7 +19,7 @@ snaps:
     name: azure-kernel
     type: kernel
   -
-    default-channel: latest/beta
+    default-channel: cloud-init/beta
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2026-02-10T16:08:48+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaYty9AAKCRDgT5vottzAEigoD/9zKjbWMBvtKKOy2S+x6RSWIBx5TOrHjK3X
-mU/DhWaPkk2Se7Di2xolqanoq1Y7eAbp0scrmbczMSMn/6PSbVOWjl6uIVxInYhaE83RYeYvGwPH
-puLz7uRMgm40CyNzRo0B5XxddpQ4vT5Dv7Gk7t2UKg4yo9LhZ8viWLD7Oy06ZrrVfUSfuen6yVuY
-UaxRvlhWmw22ywbHV/yoKctTI9zSCc9TSxcSA2KGX7FzXJIsT+Bsp/uxc2mcS4cvN0PDqbxtV8zK
-z6bjPgWADDdp4bdCOF2Eoz6SD+TrGHD1b7m7qNlMehgZv0GVTKkqqn18J16RPsj67HhSeygwRqDj
-kiVXg3lmmLkWJP1quQDTqWocZH16sR2+UUJ0CwNT3Y8O1j6rM7Zk2lMQiaF73IKCyoJqm7g/p/12
-ojw+UBPibYSnniTKr1hfvUYnT+fbQ1JKHOsdH7UcZsXPmBwtWjyFUoQOXememLGSFFGxbHUSPD12
-6L1ybEipxMXJkBiSYa8fwO8uLlEd7SoJybtxBOVdvM8TgG9jc6inD0Vg7NzbMSzJLoMmI2Z2032q
-fgufgsRL5o13XmIQxKkU1TAHaRXsdetCpUuLjcYCNbQFwBg0JWvRZgVPETIJwkvGB7ay7R5BHkGX
-aBSGqxbNRd8j5gnjc5OZumCD7a+5NJwJGuSJV4OZfA==
+AcLBXAQAAQoABgUCadavAwAKCRDgT5vottzAEjp1D/49EZ72sTNMLy93qj8n/VX6TMpGY4Xp2pZU
+FljXC3TnEIUUFXZY2e6KXsJi7El87KjTB379bD6IjzM+iAr+vbi7loCUPvapN3LPbpU9rSnwu3df
+Er4twSbhc+mQWH8V4y6+jeLEoZIzU5CZzWOCkHZ1xl5z7+doAjd/ovJkKu0lSyARkvIZmujc/lOc
+eWvYjQa6z9/AE4TX6u82aUzv56eNCDMoApiGVma3tbS80ULCTeFon81BKJJxB52BRVIIrSwYCRV6
+D2Lewsb3mXBDSVlY+SQ1jXBJakZGheBCifWe04g0Ol7v+EFsLx+7mAVY2ZJXkD1H+L/3bIjybCn8
+okk8/0kUlq5jsI6+pNNvA41lAUibJ+VVczAKqaH1WX0W56zdBMS+RbD+irqruW9/xeSUI7UqNZKL
+zM+7sQs4uOWKU5/dw2mKT3m5Gb+QNtRdBTPNnuuE9La83HXgh4MiKIlkL9x90sjxrHba+NmEN2YB
+3AKWKzpfoM34davY64hzgkUvMgBY4RRUw7mbbum7q2hr0Gu5EZ3G9PEy1tUYUWCFXhf+/HqHT+2Q
+lGf0XeGswi46WXjP2C5rYbdEhz4IKa3xSYvwJ4ElG3AZA2OpHIQ6vBFJEMB1oiusIgVw8nytZhfc
+vwPA6MplSl3smsBynX4uu+48bDDUapOpNKOVnqsW7g==

--- a/cloud/azure/azure-core-26-amd64.json
+++ b/cloud/azure/azure-core-26-amd64.json
@@ -8,7 +8,7 @@
     "timestamp": "2026-02-10T16:08:48+00:00",
     "base": "core26",
     "grade": "signed",
-    "revision": "1",
+    "revision": "2",
     "snaps": [
         {
             "name": "azure-gadget",
@@ -25,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "cloud-init/stable",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/cloud/azure/azure-core-26-amd64.model
+++ b/cloud/azure/azure-core-26-amd64.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 1
+revision: 2
 series: 16
 brand-id: canonical
 model: azure-core-26-amd64
@@ -19,7 +19,7 @@ snaps:
     name: azure-kernel
     type: kernel
   -
-    default-channel: latest/stable
+    default-channel: cloud-init/stable
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -36,13 +36,13 @@ snaps:
 timestamp: 2026-02-10T16:08:48+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaYty9AAKCRDgT5vottzAEppCD/9x3Ou/SeOZcKd+t4A3YitNupkqtkxtZZtU
-+Be/3l9aytiUjSRtHwIWsQy1KQ1YlqHHydITNwmngeY4BWbnIcIyjvHov2DaXSehWf9KOvgBvzuC
-c+RkjdeciSF6Vj6DZoeQzNb/0a1mDrnQgsz4aas7KVH2Qw/NtYMYIhDRfpchkrPLG2zEpjKbNcev
-i/TQP+DKf84/jaNb6lty1qolDyh2aR9oA4TX4C/p57aD0Eco6a4kYngDcOEeYP3bsp0/U5Ynp6pt
-XXYJEV/OZ9u3TKgB3q4HP9TOY9Vx6u+0MOjxlCoSdyGdLA97WtMdeXYF4ie0k/miEAHhDKtTYFsn
-Jl4W0CmYitYF7d2vKkMqgkC8a0i95DGWCft5L8zbsW6uCwX71VGAeUw/jba2trHL1lUyAvXtdbA7
-p4k+4HaFdEcCHtNUzY1BVenC5hUfi5DVlDaq3kLNfooJ2JTokqwoKtaGeSK/q2rfBKFk4TnOPHp2
-Sd6cib71ba81s5dRObH5m+BudlcuqpTt0HE1qMgCwIyRlwVi9a1VLN87dzAnIJKGv7UvJYSQK63+
-sl7SdvWAujTRT2RnD1gsD844sCAAyV+YTAGTAU0vCnIqxmcoW6iSaOA75txejZAxdVipK2tvJzGT
-TJUNQIZEeReJCHWHvzaFBaVLZASjWCe5lgIJm6HqHQ==
+AcLBXAQAAQoABgUCadavAwAKCRDgT5vottzAEg3PD/45TYF8gs3hWQfeH6/3PZSgMMHks5bh2IJQ
+lIHOhExXjt6BIQEYWXbrtYezatzpKTFTLeTwHlEtDKoxEJKBBU+Iw0RMF9upTP87xMLoN37DNtzA
+wCfNJc0EHIbn2H7Iq0PSnV3AUiXSXhYaLUaVunKjfDpmZttkJaxTYQPYA7oK/thBn0BPnb+OBRKa
+he7gKLlLaLzpPtAG272ABqD7J47hFpJB5lmikNhfEO2z0sKAf6Fj+h3ROwMjf3uf5yB2K+LjPG7L
+zYyi1po+KSxDTw+6MHB1F56dogcn0t2GhUNz/8XzQoNdq9TJkglX7XmDn3WqOuKKLQl39iIdk+uO
+3VJDwMon0x8024s+xo+wo/H+TJRR1DlnSf3FxSNbIinBTTTBipbCbhUrjLV/NMgZs+GhJU/L/CJl
+2XGc4rbCYWLI8KDyhDhZuXk9m54F8jTbr0mK+z7/Yo9esKsojS+SB/TIMoSNu/xgKXOJ9Pgi0fmL
+MMMB2mvmOQic+DdOksmc+KlUOtz8Mx++wFNMXU9BEaAae6aZVVeGAlZF3VM2+JNTFI/A7Ax4dYMv
+gchQ6V3r3D7MhUBxLc9cWDSSw1TvQmXE7uCxx2jc9AHWPbqqmF1d7vNNhFYA6aavAgvIDCBqbbuL
+gRGBFDEr13Ei0eUel20xNd4uJSWp73Q4VJjFPuCKCQ==

--- a/cloud/gce/gce-core-26-amd64-dangerous.json
+++ b/cloud/gce/gce-core-26-amd64-dangerous.json
@@ -8,7 +8,7 @@
     "timestamp": "2025-08-25T14:45:00+00:00",
     "base": "core26",
     "grade": "dangerous",
-    "revision": "1",
+    "revision": "2",
     "snaps": [
         {
             "name": "gce-gadget",
@@ -25,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/beta",
+            "default-channel": "cloud-init/beta",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/cloud/gce/gce-core-26-amd64-dangerous.model
+++ b/cloud/gce/gce-core-26-amd64-dangerous.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 1
+revision: 2
 series: 16
 brand-id: canonical
 model: gce-core-26-amd64-dangerous
@@ -19,7 +19,7 @@ snaps:
     name: gcp-kernel
     type: kernel
   -
-    default-channel: latest/beta
+    default-channel: cloud-init/beta
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -37,13 +37,13 @@ snaps:
 timestamp: 2025-08-25T14:45:00+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaYTvuQAKCRDgT5vottzAEnaFD/9xHWFNfKHEF5aFkVgTkUqIxX3ClTQbcWVJ
-vy0wJ3KxXnPjIY1HMS7U5fdPQPMMDGthD9Uzyn4Ovkbr0xMPXOzDMb0rZ6Arxd3MgiQTHniru+5o
-1Zi2VAvysGk9vKaS90prXU73eKxfT5xHe/4a/irXJHNR65JDf7nI/4pgY6t2a32aUtFvbtBGgvwm
-PH3Q6o5J++I2oY7MnRQudDcVRsa3IktQgMUXjSkW6Wa8UDG370ZXTN0lLq2U7/jBWBgd7LEWRre4
-u/onoTHFladaKf71fLandSTuDR+lohkh/Css7AdPdO8mZLHQ/50T+mu8PxhpvMKFOPP7NdC0Zquv
-bVfqc55IIAPo4go77vaBRggO8RHf3+kM2285U2rq/DUHAvnP5rb4+jgI8EDf3sWFMBmewW9DGtRW
-OMGs+t/TWaBD/plBc5ExRlcR3dt7mqvtPYXLTUb6qE+g2NNOV7JOOT+oWp1UaBx4oswafxAm4XLt
-JqzU1BBGPLvsRk9m7n2PDmO+IGcg4NQHQ8LkEMa0saAJMi/lJgq2gVg4kX8bgPPONR8N9RegJowR
-ZZ18QjQcHtmkgWzAnil8skTvSZPtmgzp2tokJ9Wq8U4Ja216vaqVOttddCHmh0+9ADlt2v23xuqE
-OYlIgj22iK/bCAfLjc4QPsMLkgCZb22kkTrWW8eb1w==
+AcLBXAQAAQoABgUCadavAwAKCRDgT5vottzAEptfD/9fPxOgY31mjietHBxiDzmIWECv++NKS3gw
+JHBN35sHoJMDd9YC0pps0Ix5RNwmTa2be44vKqlsY9khaFTplVF+ROeoOttbnvJ+Mj/ases5GIj4
+AEyjbNtzOzS0ooWab4gQaTFj0TGml89bEURYwoUtLGHF4o/p9D1cmxjDOVPvRxOW1SJdmhLV3BSo
+Ldv0J9shaDSeh6l8U1aAKBIoXlqCbs0ZVsW43jYJWugGl2ZX+RZqoLF/AndFT2WHRvONxyeSC6lJ
+qskXxRCQ4asRx1ha9YXdJrzEBLl76hbaH6RyUHJj4szsMsT45TdqBa2d3JosWajz0NNdB6S9d2O2
+Dx1lAEhi7BBnGUDgeNq56sfFQ0dEMhhm636YygzhFhLuDhhhqfbaqsHRRFOTcyAGG5QhBaIGCHmP
+pImjOYs5zkbYJfdSBi4ySlAWHve6tgN9KC+Hw6MyDxFuKtRO16BRWMuhYTyVV3tISZDXTNIUmlsT
+cpie+KwGLTYG/7DErBPx++IERY7rv4fwbYsREj5BrZqI6604d8dGNaHoOvibY4iotDrVOwy7drL8
+IaGlZIFRji1malOLJk/4w5ybYA1UT18ZWIsezRhVVcmuiSgWBq44umnYVswA5kPbGWFZkFd5yXxM
+5d/UhrGEyY3eo9lPkjrGgcmveZcxAu2/1bH38hzufg==

--- a/cloud/gce/gce-core-26-amd64.json
+++ b/cloud/gce/gce-core-26-amd64.json
@@ -8,7 +8,7 @@
     "timestamp": "2025-08-25T14:45:00+00:00",
     "base": "core26",
     "grade": "signed",
-    "revision": "1",
+    "revision": "2",
     "snaps": [
         {
             "name": "gce-gadget",
@@ -25,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "cloud-init/stable",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/cloud/gce/gce-core-26-amd64.model
+++ b/cloud/gce/gce-core-26-amd64.model
@@ -1,6 +1,6 @@
 type: model
 authority-id: canonical
-revision: 1
+revision: 2
 series: 16
 brand-id: canonical
 model: gce-core-26-amd64
@@ -19,7 +19,7 @@ snaps:
     name: gcp-kernel
     type: kernel
   -
-    default-channel: latest/stable
+    default-channel: cloud-init/stable
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -37,13 +37,13 @@ snaps:
 timestamp: 2025-08-25T14:45:00+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCaYTvuQAKCRDgT5vottzAErOSD/9i67QTXbJViwhsz/jow4zFhhxqC/OvNXym
-iysmVGio6M0FAiDxxmyi3JJ2DGXWKtNsdGhzZMPoiwKnM1TQ3NPcg2JSjAe+zj9O9IClj0spVXnd
-q4flVs2zG1axADAVF9pGiMqu7ZgF74THqBWYk8mdNI1OgHqdsZa+poPw/lK8JbTuZNtUlPGJQVW0
-Psa1i6jfYJfwGLQU15PEWYW7oH2pR4PGytWuaFXiiLhm6UbBENzXvG/tFHBJO0m4rxa/DTbRDVHX
-59bT7nt5cHZx0pcm9VMW16rMed5m6DeII4XLQ3Ok7P5TivJU8/Ng8n5kvSVHwwENmXZybJeoBR58
-9ZU6M/WRCFYpTro+Zv96+dIxFVf/Sv9Z8QCYv7mHKy4g8J8JUjuvQNkK1ufi1gkwATEW3luek3lX
-5ZL/arHaTX64fTysEpvOSGb0iSzgPzUp92RY08SKpZlOIlQlXSz5ImIHWFOPwmoRoDoJseGjraYr
-jjlZcJHGMCBvswyi9JMhF3YLHRNbq9ZNYKOuCyvrc+gTgK3XqV24Gm34CpR0eb21nXOhGRgGZEBf
-/NdWe9nyu5ywRgjoysDwmYeRX0KqGcB/8VSRXbtWX6q5MMVTPHES3bxOMcfOXLO5BDk15LL1J5wN
-PMmawEeaEx0sSjt/agGQ17IeNhaIpi9nuS38+OjD/w==
+AcLBXAQAAQoABgUCadavAwAKCRDgT5vottzAEvGwEACvCIWzQDYQ/hZ0t0BfC3jtODuixEHYzpiz
+OMBPEARfEim1QGimuQAEhc8xTxkqLMH6LgMDbbIU7WepgWdQiFcVbwcJpesx2nJwIJEkc+1K3e3Z
+ZjwjrN5/x84MMpadGQCtjGrf44toFzzDWWJqdrA+jVgFJZ3neC/r1zVPVlrWLmjTS0xRsfbN9iG2
+lWMvUpixzVSFwWx00Hc6ruzB0bH2R6IOXeF4bLub2YDD86dBhYyMtCDc9e/KMGi2YXAQfspAK0Of
+j3AY34wuP4X/gVMbrjr6QS6pDHvChjf7Lt3WwDPrUmaAuIzkVonO84+dlzWK/L/97KllriLDLFYD
+R0S+aqYZEnaPp+UBcGyC4Kf3JZY3/e5skDkuGn/7vqHQUjk0FbXQtTDRMOzKGylIJ77/TOHw6rWL
+pgJoRYzdIUDipN71NLRMSkT3Iu5dN61+/ow1O5NnLBMfqmkPEQnaW1sVVob36UaN9AoCB/JDupso
+cthEw46Xn3NtrI6dF50MP6k7xzy2lPmjiETr6Rog4QBPE6+B7WE+ReK4KvfHojKzNHTuq/j5xMYh
+GNOicYorU47lJLbQcygpKn7egbtuQa/ljZcrWylNwPAyVD0kALtbnRcyrykyTK61zuiXXgoFTAEh
+onFTpFlfBti6gxp9k8pjs68/GVTq0HaK5dejcYuxWg==


### PR DESCRIPTION
Alfonso has let us know that the core26 snap is now available in two channels; `cloud-init` and `latest` (which will eventually not contain cloud-init at all). This commit simply moves the cloud models to consume from the `cloud-init` channel going forward. Also bump the revision.