### PR TITLE
Update generic ubuntu-core-26 models

### DIFF
--- a/ubuntu-core-26-amd64-dangerous.json
+++ b/ubuntu-core-26-amd64-dangerous.json
@@ -5,7 +5,8 @@
     "brand-id": "canonical",
     "model": "ubuntu-core-26-amd64-dangerous",
     "architecture": "amd64",
-    "timestamp": "2026-04-07T08:00:00+00:00",
+    "revision": "2",
+    "timestamp": "2026-04-30T08:00:00+00:00",
     "base": "core26",
     "grade": "dangerous",
     "snaps": [
@@ -24,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "cloud-init/stable",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/ubuntu-core-26-amd64-dangerous.model
+++ b/ubuntu-core-26-amd64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-26-amd64-dangerous
@@ -18,7 +19,7 @@ snaps:
     name: pc-kernel
     type: kernel
   -
-    default-channel: latest/stable
+    default-channel: cloud-init/stable
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2026-04-07T08:00:00+00:00
+timestamp: 2026-04-30T08:00:00+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEqMLEACX1/lav0Gu8zAOSOnGPz8kGI/ykL5oCwmK
-w/Q5dqOJEcwaO4l/mWGGOq2YTnbJWLMfNoLeDwC8ScNrqieMN4Bu38DEwU3y2yBsZdohX6yujhtL
-TtuTa247YqNdiVIvnxH1imanooxRcYgBqgxnAEN6G/AlN3uqhubl5G++3PXjFuAaSMGUCYYeztfP
-Qq6RgT6EwoyOq5qvGAvyN6BLIUC6yCH3GiKwZkcRMUZC8JEJ3ZxJZuokGuirBW1NwMPBDMWhryBX
-Um6zIxy877mz7f2y23nrUjhp6GXzgBgvQjWqpRjOGYA69USNKa/vUbrvAMw5glDNKIxX2VXjQpzZ
-Qv6dYT2GqXtXvTjDCkZS3weA/OvYtByp44oLESQOfnqc2F61qW0qmK7dWglfPToZ46yxK3WknZMK
-IdhA69Lo1FsXHt7/12YsdshWkYZJPKu7TztwX6ac1jXQvBw7vWB0FSpoyRESWrc5OZYn7xpNQwio
-8N+TLNTHGK1meEBgSQmU8C7Cypqj2/E4AaZ7DywoUxEypyGlqsTF3YDonvvsvgeECkNypK+aLUW3
-GR6rg5drPGw6ggTcdUl6mnirzkuqERbJgQfR3ca9BP4fw5B1MuGWJm7PZdzSqPA/yytJdkSxONCz
-F8bwUbVfJ1mDNulSTPQd5JyIsy9bwClCx2DJhh/Eaw==
+AcLBXAQAAQoABgUCafOBAAAKCRDgT5vottzAEnZVD/9rgxCD/PqLqZW1WxXWXyZ95E/W88Z3Z/6O
+tO3R5fJ9abEyDIWesrxTyO0GIBXMU4YA21au7j2loUj4DrO5d9gPgbE/7NX2JFvNjA3VB7BBfhqO
+6apDQ4VSu35LH75M41Xzv4IfLyiMc7xYx54vUobnQzqRld02GusxW9lzXLUxJX9wtxX76Xo+LkRA
+AuiVG8MQ6z6rXaJIYe/8W08Hv/m2uBgNIRj37Axw0cvMSQvMnvrJgCJYaMEcw5WZLds7iN8+isQ7
+80t+Dxe+JRaj8yL/oUHY3/6/Ch3VRijTWNtZLDOOpEZBASq6qzT8U27Jgz5DhKjabDPQTtkacwhk
+KhVLAOG6DBzb1vde+h2Vjv/eyNzM2FnEnNjnXrHb/XFlVBno+n/mATBytpZmPJE18DnynVeB5mt1
+2CqhEOdxOf3WMDsFWdOUOIdMXCp+OZdEtihsEtvMwKWAGCBowlYukR0bpQJQwf2PEECR4gpS4CK4
+ChbyBjZSsIU7W8ody9wj65mGe2BdchfYMtjAEjsNubs+js8FA4+Hux8Gsksf4wR+ypjt9NbwWJse
+nbepV4WNTVGwntjRUorlg+sFt3WxDzV280B6n3mDloELIy/MCxjU8KAVYhiEdSNFjsWqiQ7+VmvM
+GbGVBBs0xX5w9S2G5/FJ9mDRHOJutsyYbhzqC015AA==

--- a/ubuntu-core-26-amd64.json
+++ b/ubuntu-core-26-amd64.json
@@ -5,7 +5,8 @@
     "architecture": "amd64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2026-04-07T08:00:00+00:00",
+    "revision": "2",
+    "timestamp": "2026-04-30T08:00:00+00:00",
     "base": "core26",
     "grade": "signed",
     "snaps": [
@@ -24,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "cloud-init/stable",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/ubuntu-core-26-amd64.model
+++ b/ubuntu-core-26-amd64.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-26-amd64
@@ -18,7 +19,7 @@ snaps:
     name: pc-kernel
     type: kernel
   -
-    default-channel: latest/stable
+    default-channel: cloud-init/stable
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2026-04-07T08:00:00+00:00
+timestamp: 2026-04-30T08:00:00+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEk5ZD/47wHlWk+ZxqTh0NatV7pukIaca/fsTuvB8
-wBlaqBrMswFK6yh+jSsxpLrTtMyOrQ96GlhRw64B9X0k3PxEpKAFFChpYvzEWSTaUnPj5tEqemhb
-9SNs4SxfQEA219frohoi7i1FtzbZxSj7Su9EKPJHbi0n8tVUBFM2Wl26i27HTs86xhtkmLCe6OMN
-8aCjNL98JJNF/ER34tBWRhsL1QDS8QMqDLnojkwSU7NIkpLX12TNDTNVXHVrANA8Zv4WqIc4m1cj
-qkHyjB90DhiVvZwj63kgrhwhpMsh3wHLSVyhuV+lG9s88iJ3pIPaM966w5C9BRTf9cvXqD/j2XN2
-0wsVa0eXPR4tRQMy+DF3I0g+f9sqiAOzr9GKR3Jt109F+UcPr2UoRpvu5jcQWqwGsAfsINbJTWLf
-WZfhAI5J2ED7nc50dq2iz0DkOr/+0MiDmEZR1xpchSQdrWHkbLkmPYoJkJQFnjkqz47rilRzkWGV
-APVmoV1frpWIizDxoNGyd64lzbyHdgV10sy46Bj/4EfX5TMiv/wv//fN/I8QPL1M0G87JV4DsZ5S
-/P8Igy6Ob7jiR8GINVuH2Xby/mmWdRV4OuRRMoTNjvVPIiXI6aBEPs8pSduuWM4pW6J3sn7zzoDq
-xQnaa2Qg8ugcpH9ZqufMQEttrALLFJdez0Kb+spLtg==
+AcLBXAQAAQoABgUCafOBAAAKCRDgT5vottzAEjFjD/9ZZpJfMblQCxKLbmDM1dwqXZsuFJyEkdAT
+lQ3M/vhSusBIevje23Yetq3eCMsWz0Rk5F/hxrA6NxatQ6nISSwubEDLiamp45vMWT37/5lZNrKk
+SkueSO6cM8ArylAdZtsKRE/o8Sau+EdPdRtbJUaOX67zfjR4qdx8pVTbTwsEqhlgSs03z8/6+xXz
+kRoeE9N5R2GJJ2bp7WsBtQzDXLIwayjUX9tV9RsTSQk+qzxQLyB7wCly6GrG+GZEtvvdjplmP094
+FOP16sgiHJuM6oDBrHijWb38Fr4PZ29kaHG9eNWNSyla4lDwZo2vlgyDzhfZoLddWAQ9iUYRyPSf
+oUWRKuhoAW61ybYrUCYDpij7W/kkyUOakzFQa///EnsX4vfC2J2o1aJsN3OWXLnoH1g1woLvxT8e
+Xz5O27VxdSeAwApDsiLg2OSfsFDs+fduF93lOwPel5BnZQ7U+No3xV0K958lI04Qh2537fjSTBe4
+C2Bp7bvMbwfU44Ng2E7yv9SBPFVMdyP1QeWueB75V/yAqON8K887iwWXX2DR1ON3mVPDFNIRy/Dd
+/9MVNjyqoPylpDIlbT+bb+yT2ciG/18XAZ2L6VNzbTRbsXrHpcQMYGXd3piFqkkeRKPnxRMXslwb
+NidK9JkLNg/vITyKyE7Trf81mBEcIyoeprZX0OKXsQ==

--- a/ubuntu-core-26-arm64-dangerous.json
+++ b/ubuntu-core-26-arm64-dangerous.json
@@ -5,7 +5,8 @@
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2026-04-07T08:00:00+00:00",
+    "revision": "2",
+    "timestamp": "2026-04-30T08:00:00+00:00",
     "base": "core26",
     "grade": "dangerous",
     "snaps": [
@@ -24,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "cloud-init/stable",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/ubuntu-core-26-arm64-dangerous.model
+++ b/ubuntu-core-26-arm64-dangerous.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-26-arm64-dangerous
@@ -18,7 +19,7 @@ snaps:
     name: pc-kernel
     type: kernel
   -
-    default-channel: latest/stable
+    default-channel: cloud-init/stable
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2026-04-07T08:00:00+00:00
+timestamp: 2026-04-30T08:00:00+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEgbmEACQJzaDT5gLnTfmUZg+xIaAPUvVaV/5QFYj
-QvSfeo+xo7WdnJOQ+bM9iMzuEcyUonpqhtXAN/Rt1MRxMoVihhkANS4bULtmP5irguYolHy/pBwP
-rbyMg/rGf783/WmyozvVI+aw/UTdgseuJ/ypoiSRF7Ad3et15T00peTbNFFcu8lW+I1UYavR/G03
-M0MC7fIi9Ha7gRnBaByHd4RWbHtIj3bJT3eqYaUzWR2wKuZREqJqFjONXeg6thYk3Gx67JU8HTYm
-KCxRI6/zjJWMAbyAkGOsZA0JGgrq9VXmprtiqMMAMB1SD27MBMXnRtLjQ1IQ2pgo1ZrHnip0A35D
-LYUwl6pJc67AAGlKgVZa+o5VRqeaQfEChNoExcaPsjIyrT3ZocgWB3GjOkUdvBGvdkMigcnU/Am2
-WIuh0sZgrf3asCas0LBkrTGOfhNsP8eGntTI73eXC6HDc4JNU9/4LttvWe4i3fcb118cASEI6cqF
-+vcQCp0oUxKEKl6T1NrASlJCWAAEvOWDu27kjxJqZWK3lr4pUB6+JIBlKTu4vwwb7/Jj3zVDd5QE
-AkbpLgG5N8SGP9jvvQWdrxRhK9vRFSmwgqZYafIQ/0c6uQ91OaoX6DB1yM2zrCFBP83Ctuf0EvW8
-ZIjPZPlZUSRVZliXif8kaYh0mW2L7qedR3LWgd4hcw==
+AcLBXAQAAQoABgUCafOBAAAKCRDgT5vottzAEtnpD/0ZyPEMaXUof7ybtzbhZqpx+wd5eAvIZaR5
+hHc27sLQwB8F1GmPXQEaNulRQsIb/zKb0apizgc6rXfUMrY7awHFF5JML+RwQjixsqx1DI2SuGk8
+Qi8I8dMxLO8k4/TYhPbdLI5SO9Gpr4DL6cgNjDlf3ZxAwpL6TaqeKCUFb3DIbjGby0N4ZcEZgJo+
+5D0F4dfv6LLMsGWDNnrzpLFp9UPp7X/uG4SgFNmQGlN5A4VN66iv+O8bVrE2O85jLkGs5OwAgD3T
++AMYouOzM2npipXRrm7/JEa8klnH311kU0jrQhzkidqu84AcCMExGbOaPjQkL3ET7kCPe8Cs5QFF
+tT91fzmgLy8nhVCkM69UyBpZFXwCE+UikwomhN5iF56O87MaROGdKZbOT3IbekkMhE441vdCtk//
+uOyw1BHuY5qG5E00W6cDVYmnkfo9GS4lSePCM+d/6YjzBiT7lr17f8tjfJqdkG5CM6JVCDvLQXb9
+Rdq1MFsyEaXQI8vl3xbG1kGWUzlWDGQ4TF0oOVtnYoXWfBqMJsZRgrSZ4Jg9lBleRRAk39T3r4om
+Org3t1fFLweGVx5rWFI+E1g9Nr2GGqb1C5oCAn9UiaN/W+dWHAlkzVPl9X9F+dAuiRN4JgAx6lPO
+TrtwHc9UAsILLazSwsrVGOD9LzaksIH5rjCS+lb3qw==

--- a/ubuntu-core-26-arm64.json
+++ b/ubuntu-core-26-arm64.json
@@ -5,7 +5,8 @@
     "architecture": "arm64",
     "authority-id": "canonical",
     "brand-id": "canonical",
-    "timestamp": "2026-04-07T08:00:00+00:00",
+    "revision": "2",
+    "timestamp": "2026-04-30T08:00:00+00:00",
     "base": "core26",
     "grade": "signed",
     "snaps": [
@@ -24,7 +25,7 @@
         {
             "name": "core26",
             "type": "base",
-            "default-channel": "latest/stable",
+            "default-channel": "cloud-init/stable",
             "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
         },
         {

--- a/ubuntu-core-26-arm64.model
+++ b/ubuntu-core-26-arm64.model
@@ -1,5 +1,6 @@
 type: model
 authority-id: canonical
+revision: 2
 series: 16
 brand-id: canonical
 model: ubuntu-core-26-arm64
@@ -18,7 +19,7 @@ snaps:
     name: pc-kernel
     type: kernel
   -
-    default-channel: latest/stable
+    default-channel: cloud-init/stable
     id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
     name: core26
     type: base
@@ -33,16 +34,16 @@ snaps:
     name: console-conf
     presence: optional
     type: app
-timestamp: 2026-04-07T08:00:00+00:00
+timestamp: 2026-04-30T08:00:00+00:00
 sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
 
-AcLBXAQAAQoABgUCadmKOQAKCRDgT5vottzAEnpmEAC3dAfVALESawaMCW7wMZPVvTr04fWUQUVo
-fZTWiCmOcrDjjT2CGoXEb+Tji+pSGW6UXoCSHnPA2PEYN/DFsqR1+CKCbvO2Q5fQCxcVCLCpLarg
-DJSaPwc+XB5V36rMS4fZyVXmsfQ3zkB3TUXZGLMsygCP89xO5GqFG1mnJwX+UxFSSbFIq7jHsWXF
-oHhHV/MxtO9ZJWMAfP51PH2pVE6hDkL4PO9iTQJGqooYaFrXzOk7permDM5dkwtFEdm1NaHWrKuo
-bUJaoMez20OTtKmz9Yv09Um4y9sX3T43Qk8VEm0eIjIH7SgNrHoE3Emu57ggV81dcQk2iJr8KS98
-r5A6L5V13Bpqy7yxvTDuFW8o6+TBXr7u0+91bY/Sv+S8jXYYnqjTkegEdzFu/C8yhm0wY2DSVHmN
-Gv1vr6/ETpc0uzK+wTNdJjQ2RmmTli58stxDRS4KFRRpQrvBZ0ckDjJxgseCjIaCuCwH/aXs64mJ
-4RllVQMuhIorJ1ywDh1FtUfszYZWtrw75uPONliaNQThTtWAPYsUDAhgL7+GA0jjCgKeRulT6C15
-z6tkZFeS329jFyIgn8s2Sbu7gj2ZV8DxJrmXMep0HDodAdDcor3fvoG/yOgRrdiIC6IDdm2luoIH
-0rl/AwoT8sQLk2zqPrh5NYXG5ACST5Gj4G+5IfcDCw==
+AcLBXAQAAQoABgUCafOBAQAKCRDgT5vottzAErJWEACuV8WbmoW4uklLBT4qNxqbI/LeOeuGgHd3
+4VToQzR5AsRPGzA3uQdMzY9qlkuQGlHksPQEIj2ZtnjsPz9zaBrZgga/zl6KbCvSGg7ldBA2cKOv
+iI/5LNwUoQYM67e5XdbPJL4qnUN8Ok4ADhqYuZqKB+ZXNrwf5lUyklA3qcgo52ch/QBgZl0yvQEF
+LNsvyap2rawPSoFsXiKGhC6AFp8u4vMz0IJUaCx2IXGs4CgWCj2MGDqouvny5zrF5nUtwObvsxX5
+LHdFRf44jHlX8H42P3njkx8qqLkduaRp9J1i80/vZGKKp+/3+TtWW0YZUDarWWoem1Mz7oc2UvoY
+OV12J8h+fGfVPzpxz2fL6pMCLluxWtCxnghRFt5XG6OQ7pVvUfP/wpCn+MJmBU8kiLSz+mJLMqgt
+NYwcwYWnPBiCRmSC+uoKdZZcHpavlp9Z4+LpNSvDabyasqoMnd6cvwSwS8onNCl4A1WpkbCV9m2m
+YaWHe51W254GUxY1fTEgA+/Y2J8fBRPDcSyZPLbpj8pxkcaDrVcC6mabq2DgaZvODyLXZ5Q8z6Ng
+vYgFR2kN6DEvsdfDVrCJm4I79Ph9X8gf5F5Axx5RCdfq7LbLWLWd/wnXEGuYZvfqN2e09B0VODyr
+4WVHq8/rsvIsb3kPCB5zXEVShpWTZFYcTWVtpw/Lqw==


### PR DESCRIPTION
Change core26 default-channel from latest/stable to cloud-init/stable so it can be used by multipass and bump revision.