### PR TITLE
26.10 classic: introduce models for stable & dangerous

### DIFF
--- a/ubuntu-classic-2610-amd64-dangerous.json
+++ b/ubuntu-classic-2610-amd64-dangerous.json
@@ -1,0 +1,113 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "model": "ubuntu-classic-2610-amd64-dangerous",
+    "architecture": "amd64",
+    "timestamp": "2026-05-06T11:17:20.0Z",
+    "base": "core24",
+    "grade": "dangerous",
+    "classic": "true",
+    "distribution": "ubuntu",
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "classic-26.10/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "26.10/edge",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "components": {
+                "nvidia-590-uda-ko": {
+                    "presence": "optional"
+                },
+                "nvidia-590-uda-user": {
+                    "presence": "optional"
+                }
+            }
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "core26",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/edge",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "bare",
+            "type": "base",
+            "default-channel": "latest/edge",
+            "id": "EISPgh06mRh1vordZY9OZ34QHdd7OrdR"
+        },
+        {
+            "name": "mesa-2404",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "HyhSEBPv3vHsW6uOHkQR384NgI7S6zpj"
+        },
+        {
+            "name": "firmware-updater",
+            "type": "app",
+            "default-channel": "1/edge",
+            "id": "EI0D1KHjP8XiwMZKqSjuh6W8zvcowUVP"
+        },
+        {
+            "name": "desktop-security-center",
+            "type": "app",
+            "default-channel": "1/edge",
+            "id": "FppXWunWzuRT2NUT9CwoBPNJNZBYOCk0"
+        },
+        {
+            "name": "prompting-client",
+            "type": "app",
+            "default-channel": "1/edge",
+            "id": "aoc5lfC8aUd2VL8VpvynUJJhGXp5K6Dj"
+        },
+        {
+            "name": "snap-store",
+            "type": "app",
+            "default-channel": "2/edge",
+            "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
+        },
+        {
+            "name": "gtk-common-themes",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit"
+        },
+        {
+            "name": "firefox",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk"
+        },
+        {
+            "name": "gnome-46-2404",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "ew7OxpbRTxfK7ImpIygRR85lkxvU7Pzt"
+        },
+        {
+            "name": "snapd-desktop-integration",
+            "type": "app",
+            "default-channel": "latest/edge",
+            "id": "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
+        }
+    ]
+}

--- a/ubuntu-classic-2610-amd64-dangerous.model
+++ b/ubuntu-classic-2610-amd64-dangerous.model
@@ -1,0 +1,104 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-classic-2610-amd64-dangerous
+architecture: amd64
+base: core24
+classic: true
+distribution: ubuntu
+grade: dangerous
+snaps:
+  -
+    default-channel: classic-26.10/edge
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    components:
+      nvidia-590-uda-ko:
+        presence: optional
+      nvidia-590-uda-user:
+        presence: optional
+    default-channel: 26.10/edge
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/edge
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/edge
+    id: cUqM61hRuZAJYmIS898Ux66VY61gBbZf
+    name: core26
+    type: base
+  -
+    default-channel: latest/edge
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/edge
+    id: EISPgh06mRh1vordZY9OZ34QHdd7OrdR
+    name: bare
+    type: base
+  -
+    default-channel: latest/edge
+    id: HyhSEBPv3vHsW6uOHkQR384NgI7S6zpj
+    name: mesa-2404
+    type: app
+  -
+    default-channel: 1/edge
+    id: EI0D1KHjP8XiwMZKqSjuh6W8zvcowUVP
+    name: firmware-updater
+    type: app
+  -
+    default-channel: 1/edge
+    id: FppXWunWzuRT2NUT9CwoBPNJNZBYOCk0
+    name: desktop-security-center
+    type: app
+  -
+    default-channel: 1/edge
+    id: aoc5lfC8aUd2VL8VpvynUJJhGXp5K6Dj
+    name: prompting-client
+    type: app
+  -
+    default-channel: 2/edge
+    id: gjf3IPXoRiipCu9K0kVu52f0H56fIksg
+    name: snap-store
+    type: app
+  -
+    default-channel: latest/edge
+    id: jZLfBRzf1cYlYysIjD2bwSzNtngY0qit
+    name: gtk-common-themes
+    type: app
+  -
+    default-channel: latest/edge
+    id: 3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk
+    name: firefox
+    type: app
+  -
+    default-channel: latest/edge
+    id: ew7OxpbRTxfK7ImpIygRR85lkxvU7Pzt
+    name: gnome-46-2404
+    type: app
+  -
+    default-channel: latest/edge
+    id: IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu
+    name: snapd-desktop-integration
+    type: app
+timestamp: 2026-05-06T11:17:20.0Z
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCafs21QAKCRDgT5vottzAEmxhEACLAcIcV5aXEWu1qVooJatYDKJTCtlHqhQI
++EHt0c1gSYI7c0fQzJ2bEU7deF+qzuUQsAdH3cFgvbpuIGwI6uWmOOOFlCODRzk3favzfJ8KaVzO
+joguyE/JVemPPJa8Fri2ZyMBu9BJ6ctqJUQDkb7TO1mW7O9YCw2tEn1tdt5UTfCyPm/CM6jt87QX
+Dz0r1UUMYedou+0A/T/zQU/koiSCQUloXFWDDX0w6vgnlS4MyeNB7EZEnYxlvpuRbrDN9EmIgIKD
+izp+cHpQ2erxCvKGjcSQg1I0lSmXrmlHxl6kjhdK6jwC35ZaoCgELA5kMULybhbavda+jkDF7rEs
+Z9RMSkB7LWbJbyJ6Jvu7pfmrRP1sUT03fZ78K2gId1AQbJT2isqrYAgPQ9VXVol5BaF5Ud97XZeb
+UhMsTanKecrR1k2wvciEh3gsk87Oalqlr7SjSGq5nhc9oQ1GyouXMuyWq8vCbjfAfsuZ48sfXT7O
+ZFr+svUn69nK4hiUReEQo0pdtGY7VBfKIdKkOlIXVrRvJN2YZb6m3tW6tGICg1r+7zkyELLmPahE
+P+y+VtHKfkJUD/2cW5TA1mrb/aBdJWbrxcQxd6bWMTPSJocnl7TLcVwfHOGxGjN9HbXzNbZbC885
+tdiWwNMs5OJcabo3eGcGMQQStTiALOBrghRrbzAWVw==

--- a/ubuntu-classic-2610-amd64.json
+++ b/ubuntu-classic-2610-amd64.json
@@ -1,0 +1,107 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "canonical",
+    "brand-id": "canonical",
+    "model": "ubuntu-classic-2610-amd64",
+    "architecture": "amd64",
+    "timestamp": "2026-05-06T11:17:20.0Z",
+    "base": "core24",
+    "grade": "signed",
+    "classic": "true",
+    "distribution": "ubuntu",
+    "snaps": [
+        {
+            "name": "pc",
+            "type": "gadget",
+            "default-channel": "classic-26.10/stable",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
+        },
+        {
+            "name": "pc-kernel",
+            "type": "kernel",
+            "default-channel": "26.10/stable",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "components": {
+                "nvidia-590-uda-ko": {
+                    "presence": "optional"
+                },
+                "nvidia-590-uda-user": {
+                    "presence": "optional"
+                }
+            }
+        },
+        {
+            "name": "core24",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "dwTAh7MZZ01zyriOZErqd1JynQLiOGvM"
+        },
+        {
+            "name": "snapd",
+            "type": "snapd",
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4"
+        },
+        {
+            "name": "bare",
+            "type": "base",
+            "default-channel": "latest/stable",
+            "id": "EISPgh06mRh1vordZY9OZ34QHdd7OrdR"
+        },
+        {
+            "name": "mesa-2404",
+            "type": "app",
+            "default-channel": "latest/stable/ubuntu-26.10",
+            "id": "HyhSEBPv3vHsW6uOHkQR384NgI7S6zpj"
+        },
+        {
+            "name": "firmware-updater",
+            "type": "app",
+            "default-channel": "1/stable/ubuntu-26.10",
+            "id": "EI0D1KHjP8XiwMZKqSjuh6W8zvcowUVP"
+        },
+        {
+            "name": "desktop-security-center",
+            "type": "app",
+            "default-channel": "1/stable/ubuntu-26.10",
+            "id": "FppXWunWzuRT2NUT9CwoBPNJNZBYOCk0"
+        },
+        {
+            "name": "prompting-client",
+            "type": "app",
+            "default-channel": "1/stable/ubuntu-26.10",
+            "id": "aoc5lfC8aUd2VL8VpvynUJJhGXp5K6Dj"
+        },
+        {
+            "name": "snap-store",
+            "type": "app",
+            "default-channel": "2/stable/ubuntu-26.10",
+            "id": "gjf3IPXoRiipCu9K0kVu52f0H56fIksg"
+        },
+        {
+            "name": "gtk-common-themes",
+            "type": "app",
+            "default-channel": "latest/stable/ubuntu-26.10",
+            "id": "jZLfBRzf1cYlYysIjD2bwSzNtngY0qit"
+        },
+        {
+            "name": "firefox",
+            "type": "app",
+            "default-channel": "latest/stable/ubuntu-26.10",
+            "id": "3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk"
+        },
+        {
+            "name": "gnome-46-2404",
+            "type": "app",
+            "default-channel": "latest/stable/ubuntu-26.10",
+            "id": "ew7OxpbRTxfK7ImpIygRR85lkxvU7Pzt"
+        },
+        {
+            "name": "snapd-desktop-integration",
+            "type": "app",
+            "default-channel": "latest/stable/ubuntu-26.10",
+            "id": "IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu"
+        }
+    ]
+}

--- a/ubuntu-classic-2610-amd64.model
+++ b/ubuntu-classic-2610-amd64.model
@@ -1,0 +1,99 @@
+type: model
+authority-id: canonical
+series: 16
+brand-id: canonical
+model: ubuntu-classic-2610-amd64
+architecture: amd64
+base: core24
+classic: true
+distribution: ubuntu
+grade: signed
+snaps:
+  -
+    default-channel: classic-26.10/stable
+    id: UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH
+    name: pc
+    type: gadget
+  -
+    components:
+      nvidia-590-uda-ko:
+        presence: optional
+      nvidia-590-uda-user:
+        presence: optional
+    default-channel: 26.10/stable
+    id: pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza
+    name: pc-kernel
+    type: kernel
+  -
+    default-channel: latest/stable
+    id: dwTAh7MZZ01zyriOZErqd1JynQLiOGvM
+    name: core24
+    type: base
+  -
+    default-channel: latest/stable
+    id: PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4
+    name: snapd
+    type: snapd
+  -
+    default-channel: latest/stable
+    id: EISPgh06mRh1vordZY9OZ34QHdd7OrdR
+    name: bare
+    type: base
+  -
+    default-channel: latest/stable/ubuntu-26.10
+    id: HyhSEBPv3vHsW6uOHkQR384NgI7S6zpj
+    name: mesa-2404
+    type: app
+  -
+    default-channel: 1/stable/ubuntu-26.10
+    id: EI0D1KHjP8XiwMZKqSjuh6W8zvcowUVP
+    name: firmware-updater
+    type: app
+  -
+    default-channel: 1/stable/ubuntu-26.10
+    id: FppXWunWzuRT2NUT9CwoBPNJNZBYOCk0
+    name: desktop-security-center
+    type: app
+  -
+    default-channel: 1/stable/ubuntu-26.10
+    id: aoc5lfC8aUd2VL8VpvynUJJhGXp5K6Dj
+    name: prompting-client
+    type: app
+  -
+    default-channel: 2/stable/ubuntu-26.10
+    id: gjf3IPXoRiipCu9K0kVu52f0H56fIksg
+    name: snap-store
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-26.10
+    id: jZLfBRzf1cYlYysIjD2bwSzNtngY0qit
+    name: gtk-common-themes
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-26.10
+    id: 3wdHCAVyZEmYsCMFDE9qt92UV8rC8Wdk
+    name: firefox
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-26.10
+    id: ew7OxpbRTxfK7ImpIygRR85lkxvU7Pzt
+    name: gnome-46-2404
+    type: app
+  -
+    default-channel: latest/stable/ubuntu-26.10
+    id: IrwRHakqtzhFRHJOOPxKVPU0Kk7Erhcu
+    name: snapd-desktop-integration
+    type: app
+timestamp: 2026-05-06T11:17:20.0Z
+sign-key-sha3-384: 9tydnLa6MTJ-jaQTFUXEwHl1yRx7ZS4K5cyFDhYDcPzhS7uyEkDxdUjg9g08BtNn
+
+AcLBXAQAAQoABgUCafs21gAKCRDgT5vottzAEhkyD/9bmGGMKRtIGYWH6w3UyYn5NAGf+s5hSVzS
+SZyV2EmsmzXom4vYHbxAWxQy0tlQY/QjkY8zkOxU5CDqdpGiCyQBE6sPEg7BNjCyXhIIZZrGdn7q
+qHdyX56YSvRGzE4KhoP2RIuug2ynBjF451zsEHxloRVsTiMbkTap1HukS4dR0TNIlil81+bZ/NmV
+Q0I2ngwXQp5NxRyBvHbIE8LGWcnChAttUTEmY9kXSEfJJKGufXut0Fc8gRzO7MF7qdilLba/k/im
+Ksp5bWRNVQbzjAqfmyEFrqo17/OJZycOI+bV1IV6wheHBEI3+c3Ek8MNbHNhnrJ3IngTM867Eiox
+zxS5a/m65fmL5MK9Vvsjjp52SRLinyE6IdbqQKs+GZDtM72K2lZ61nPHTa4v7kxLhb0msgXxTROD
+XQPLnNqcDFzmteuiquBvWUUX1Kov7uU+mGYLipZc40z2eqRFSnRaVnf76+n5K1IkShwxnuaJlO2q
+Rrit7zJvBX96P1oHDothrYknPWqnxH7gWCfa6Y2sR5ubI0iqElihMCtWBkSG/EzjM3yLZyHiRDZj
+Z1M9D9zXHv9NsMcW6OxPwC6QYmiIS8NJ6ypKek9WCVpaROcapp38V1deryFhwIv0kezRiOdnlCVM
+r5hAy0u+V7zaLtOSQAZKH1ko0IEWZG1q5zH6vS19GQ==


### PR DESCRIPTION
This is based on the 26.04 models. 

The dangerous model has `core26` + `core24` where the stable model only has `core24`.

The dangerous model uses `edge` the edge channel for all snaps.